### PR TITLE
fix: Use the same image name both in default and prepare overlays.

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,3 +8,8 @@ configMapGenerator:
 - name: manager-config
   files:
   - controller_manager_config.yaml
+
+images:
+- name: controller
+  newName: quay.io/redhat-app-studio/service-provider-integration-operator
+  newTag: latest


### PR DESCRIPTION
### What does this PR do?
There currently 2 main "target" or "overlays" in the kustomizations - `config/default` and `config/prepare`. This makes them use the same settings for the images used for the operator.
