### PR TITLE
ci: Build latest tag by default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,5 +48,4 @@ jobs:
           registry: quay.io
           repository: skabashn/service-provider-integration-operator
           dockerfile: ./Dockerfile
-          tags: next
           tag_with_sha: true


### PR DESCRIPTION
### What does this PR do?

Build **latest** tag by default

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
- We need to adjust "make deploy" with the tags we have https://quay.io/repository/skabashn/service-provider-integration-operator?tab=tags

### How to test this PR?
- wait github ci 