### PR TITLE
SVPI-24 - Add codecov integration to pre- and post- merge workflows.

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2012-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+name: Code Coverage Report
+on: [push]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Run tests
+        run: make test
+      - name: Codecov
+        uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ name: Validate PRs
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   go:
@@ -103,6 +103,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip yq
           make test
+      - name: Codecov
+        uses: codecov/codecov-action@v2.1.0
   docker:
     name: Check docker build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Adds codecov reporting.
This is mostly just default behavior. We can modify it to suit our needs better if needed.

### Screenshot/screencast of this PR
Examples of how it looks like when I enabled this in my own fork of this repo:
Codecov dashboard for my fork: https://app.codecov.io/gh/rhopp/service-provider-integration-operator
Example of comment in PR: https://github.com/rhopp/service-provider-integration-operator/pull/2#issuecomment-966387648


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-24
