### PR TITLE
fix: Re-enable the use of custom images in deploy and deploy_k8s make targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,13 +186,13 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${SPIO_IMG} && cd ../..
-	cd config/oauth && $(KUSTOMIZE) edit set image oauth=${SPIS_IMG} && cd ../..
+	cd config/default && $(KUSTOMIZE) edit set image quay.io/redhat-appstudio/service-provider-integration-operator=${SPIO_IMG} && cd ../..
+	cd config/default && $(KUSTOMIZE) edit set image quay.io/redhat-appstudio/service-provider-integration-oauth=${SPIS_IMG} && cd ../..
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 deploy_k8s: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${SPIO_IMG} && cd ../..
-	cd config/oauth && $(KUSTOMIZE) edit set image oauth=${SPIS_IMG} && cd ../..
+	cd config/k8s && $(KUSTOMIZE) edit set image quay.io/redhat-appstudio/service-provider-integration-operator=${SPIO_IMG} && cd ../..
+	cd config/k8s && $(KUSTOMIZE) edit set image quay.io/redhat-appstudio/service-provider-integration-oauth=${SPIS_IMG} && cd ../..
 	$(KUSTOMIZE) build config/k8s | kubectl apply -f -
 
 undeploy_k8s: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,8 +14,3 @@ configMapGenerator:
 - files:
   - controller_manager_config.yaml
   name: manager-config
-
-images:
-- name: controller
-  newName: quay.io/redhat-appstudio/service-provider-integration-operator
-  newTag: next

--- a/config/oauth/kustomization.yaml
+++ b/config/oauth/kustomization.yaml
@@ -7,11 +7,6 @@ generatorOptions:
 commonLabels:
   app.kubernetes.io/name: service-provider-integration-oauth
 
-images:
-- name: oauth
-  newName: quay.io/redhat-appstudio/service-provider-integration-oauth
-  newTag: next
-
 resources:
 - deployment.yaml
 - service-account.yaml


### PR DESCRIPTION
### What does this PR do?
This removes the image configuration from the bases and only places them in the `default` or `k8s` overlays. It then uses these
overlays exclusively in the `Makefile` to make the modifications when deploying with custom images.

### What issues does this PR fix or reference?
none

### How to test this PR?
`make deploy_k8s SPIO_IMG=my-custom-operator-image SPIS_IMG=my-custom-oauth-service-image` should create a deployment with those names as the images of the respective containers.