### PR TITLE
fix: Used SPI deployment with 200Mi memory limit for spi-operator to avoid potential oom

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,7 +45,7 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 200Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
### What does this PR do?
Set 200Mi memory limit for spi-operator.

### Screenshot/screencast of this PR
Here we can see a peek usage 95.6 that is very close to the limit.
<img width="1367" alt="Знімок екрана 2022-01-19 о 12 11 20" src="https://user-images.githubusercontent.com/1614429/150110514-7edeb35b-cd11-4db3-b6bc-3eb1898574a9.png">
Here we have on staging. It is cleare that we need more then 100Mi
<img width="1366" alt="Знімок екрана 2022-01-19 о 12 19 42" src="https://user-images.githubusercontent.com/1614429/150111287-0d5c335d-aa87-4530-8b83-4177d0a686b7.png">



### What issues does this PR fix or reference?
spi-operator is failing to deploy on staging. Possible reason oom.



### How to test this PR?
1. Deploy spi-operator. 
2. Check if deployment set with 200Mi limit
