### PR TITLE
fix: Improve status handling in SPIAccessTokenBinding

### DIFF
--- a/api/v1beta1/spiaccesstoken_types.go
+++ b/api/v1beta1/spiaccesstoken_types.go
@@ -22,10 +22,12 @@ import (
 
 // SPIAccessTokenSpec defines the desired state of SPIAccessToken
 type SPIAccessTokenSpec struct {
+	//+kubebuilder:validation:Required
 	ServiceProviderType ServiceProviderType `json:"serviceProviderType"`
 	Permissions         Permissions         `json:"permissions"`
-	ServiceProviderUrl  string              `json:"serviceProviderUrl,omitempty"`
-	DataLocation        string              `json:"dataLocation"`
+	//+kubebuilder:validation:Required
+	ServiceProviderUrl  string              `json:"serviceProviderUrl"`
+	DataLocation        string              `json:"dataLocation,omitempty"`
 	TokenMetadata       *TokenMetadata      `json:"tokenMetadata,omitempty"`
 	RawTokenData        *Token              `json:"rawTokenData,omitempty"`
 }

--- a/api/v1beta1/spiaccesstoken_types.go
+++ b/api/v1beta1/spiaccesstoken_types.go
@@ -26,10 +26,10 @@ type SPIAccessTokenSpec struct {
 	ServiceProviderType ServiceProviderType `json:"serviceProviderType"`
 	Permissions         Permissions         `json:"permissions"`
 	//+kubebuilder:validation:Required
-	ServiceProviderUrl  string              `json:"serviceProviderUrl"`
-	DataLocation        string              `json:"dataLocation,omitempty"`
-	TokenMetadata       *TokenMetadata      `json:"tokenMetadata,omitempty"`
-	RawTokenData        *Token              `json:"rawTokenData,omitempty"`
+	ServiceProviderUrl string         `json:"serviceProviderUrl"`
+	DataLocation       string         `json:"dataLocation,omitempty"`
+	TokenMetadata      *TokenMetadata `json:"tokenMetadata,omitempty"`
+	RawTokenData       *Token         `json:"rawTokenData,omitempty"`
 }
 
 // Token is copied from golang.org/x/oauth2 and made easily json-serializable. It represents the data obtained from the

--- a/api/v1beta1/spiaccesstokenbinding_types.go
+++ b/api/v1beta1/spiaccesstokenbinding_types.go
@@ -34,23 +34,26 @@ type SPIAccessTokenBindingStatus struct {
 	ErrorReason           SPIAccessTokenBindingErrorReason `json:"errorReason,omitempty"`
 	ErrorMessage          string                           `json:"errorMessage,omitempty"`
 	LinkedAccessTokenName string                           `json:"linkedAccessTokenName"`
+	OAuthUrl              string                           `json:"oAuthUrl"`
 	SyncedObjectRef       TargetObjectRef                  `json:"syncedObjectRef"`
 }
 
 type SPIAccessTokenBindingPhase string
 
 const (
-	SPIAccessTokenBindingPhaseAwaitingTokenData = "AwaitingTokenData"
-	SPIAccessTokenBindingPhaseInjected          = "Injected"
-	SPIAccessTokenBindingPhaseError             = "Error"
+	SPIAccessTokenBindingPhaseAwaitingTokenData SPIAccessTokenBindingPhase = "AwaitingTokenData"
+	SPIAccessTokenBindingPhaseInjected          SPIAccessTokenBindingPhase = "Injected"
+	SPIAccessTokenBindingPhaseError             SPIAccessTokenBindingPhase = "Error"
 )
 
 type SPIAccessTokenBindingErrorReason string
 
 const (
-	SPIAccessTokenBindingErrorReasonUnknownServiceProviderType = "UnknownServiceProviderType"
-	SPIAccessTokenBindingErrorReasonTokenLookup                = "TokenLookup"
-	SPIAccessTokenBindingErrorReasonLinkedToken                = "LinkedToken"
+	SPIAccessTokenBindingErrorReasonUnknownServiceProviderType SPIAccessTokenBindingErrorReason = "UnknownServiceProviderType"
+	SPIAccessTokenBindingErrorReasonTokenLookup                SPIAccessTokenBindingErrorReason = "TokenLookup"
+	SPIAccessTokenBindingErrorReasonLinkedToken                SPIAccessTokenBindingErrorReason = "LinkedToken"
+	SPIAccessTokenBindingErrorReasonTokenRetrieval             SPIAccessTokenBindingErrorReason = "TokenRetrieval"
+	SPIAccessTokenBindingErrorReasonTokenSync                  SPIAccessTokenBindingErrorReason = "TokenSync"
 )
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/appstudio.redhat.com_spiaccesstokenbindings.yaml
+++ b/config/crd/bases/appstudio.redhat.com_spiaccesstokenbindings.yaml
@@ -160,6 +160,8 @@ spec:
                 type: string
               linkedAccessTokenName:
                 type: string
+              oAuthUrl:
+                type: string
               phase:
                 type: string
               syncedObjectRef:
@@ -184,6 +186,7 @@ spec:
                 type: object
             required:
             - linkedAccessTokenName
+            - oAuthUrl
             - phase
             - syncedObjectRef
             type: object

--- a/config/crd/bases/appstudio.redhat.com_spiaccesstokens.yaml
+++ b/config/crd/bases/appstudio.redhat.com_spiaccesstokens.yaml
@@ -107,9 +107,9 @@ spec:
                 - userName
                 type: object
             required:
-            - dataLocation
             - permissions
             - serviceProviderType
+            - serviceProviderUrl
             type: object
           status:
             description: SPIAccessTokenStatus defines the observed state of SPIAccessToken

--- a/controllers/spiaccesstokenbinding_controller.go
+++ b/controllers/spiaccesstokenbinding_controller.go
@@ -112,6 +112,8 @@ func (r *SPIAccessTokenBindingReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, nil
 	}
 
+	binding.Status.Phase = api.SPIAccessTokenBindingPhaseAwaitingTokenData
+
 	sp, rerr := r.getServiceProvider(ctx, &binding)
 	if rerr != nil {
 		return ctrl.Result{}, rerr

--- a/controllers/spiaccesstokenbinding_controller.go
+++ b/controllers/spiaccesstokenbinding_controller.go
@@ -121,16 +121,22 @@ func (r *SPIAccessTokenBindingReconciler) Reconcile(ctx context.Context, req ctr
 	if err != nil {
 		return ctrl.Result{}, NewReconcileError(err, "failed to link the token")
 	}
+	binding.Status.OAuthUrl = token.Status.OAuthUrl
 
-	if token.Status.Phase == api.SPIAccessTokenPhaseReady {
+	switch token.Status.Phase {
+	case api.SPIAccessTokenPhaseReady:
 		ref, err := r.syncSecret(ctx, sp, &binding, token)
 		if err != nil {
 			return ctrl.Result{}, NewReconcileError(err, "failed to sync the secret")
 		}
 		binding.Status.SyncedObjectRef = ref
-		if err := r.updateStatusSuccess(ctx, &binding); err != nil {
-			return ctrl.Result{}, NewReconcileError(err, "failed to update the status")
-		}
+		binding.Status.Phase = api.SPIAccessTokenBindingPhaseInjected
+	case api.SPIAccessTokenPhaseAwaitingTokenData:
+		binding.Status.Phase = api.SPIAccessTokenBindingPhaseAwaitingTokenData
+	}
+
+	if err := r.updateStatusSuccess(ctx, &binding); err != nil {
+		return ctrl.Result{}, NewReconcileError(err, "failed to update the status")
 	}
 
 	return ctrl.Result{}, nil
@@ -194,6 +200,7 @@ func (r *SPIAccessTokenBindingReconciler) linkToken(ctx context.Context, sp serv
 		binding.Labels[config.SPIAccessTokenLinkLabel] = token.Name
 
 		if err := r.Client.Update(ctx, binding); err != nil {
+			r.updateStatusError(ctx, binding, api.SPIAccessTokenBindingErrorReasonLinkedToken, err)
 			return token, NewReconcileError(err, "failed to update the binding with the token link")
 		}
 	}
@@ -201,6 +208,7 @@ func (r *SPIAccessTokenBindingReconciler) linkToken(ctx context.Context, sp serv
 	if binding.Status.LinkedAccessTokenName != token.Name {
 		binding.Status.LinkedAccessTokenName = token.Name
 		if err := r.updateStatusSuccess(ctx, binding); err != nil {
+			r.updateStatusError(ctx, binding, api.SPIAccessTokenBindingErrorReasonLinkedToken, err)
 			return token, NewReconcileError(err, "failed to update the binding status with the token link")
 		}
 	}
@@ -232,10 +240,12 @@ func (r *SPIAccessTokenBindingReconciler) updateStatusSuccess(ctx context.Contex
 func (r *SPIAccessTokenBindingReconciler) syncSecret(ctx context.Context, sp serviceprovider.ServiceProvider, binding *api.SPIAccessTokenBinding, tokenObject *api.SPIAccessToken) (api.TargetObjectRef, error) {
 	token, err := r.TokenStorage.Get(ctx, tokenObject)
 	if err != nil {
+		r.updateStatusError(ctx, binding, api.SPIAccessTokenBindingErrorReasonTokenRetrieval, err)
 		return api.TargetObjectRef{}, NewReconcileError(err, "failed to get the token data from token storage")
 	}
 
 	if token == nil {
+		r.updateStatusError(ctx, binding, api.SPIAccessTokenBindingErrorReasonTokenRetrieval, err)
 		return api.TargetObjectRef{}, fmt.Errorf("access token data not found")
 	}
 
@@ -290,6 +300,7 @@ func (r *SPIAccessTokenBindingReconciler) syncSecret(ctx context.Context, sp ser
 
 	_, obj, err := r.syncer.Sync(ctx, binding, secret, secretDiffOpts)
 	if err != nil {
+		r.updateStatusError(ctx, binding, api.SPIAccessTokenBindingErrorReasonTokenSync, err)
 		return api.TargetObjectRef{}, NewReconcileError(err, "failed to sync the secret with the token data")
 	}
 	return toObjectRef(obj), nil


### PR DESCRIPTION
### What does this PR do?
Update the phase of the binding and also mirror the OAuthUrl of the token
directly in the status of the binding so that the users don't have to
read the token as well as the binding.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-44

### How to test this PR?
Follow the steps from the operator README to create SPIAccessTokenBinding etc. You should see the `phase` of the `SPIAccessTokenBinding` to have a non-empty value that reflects the phase of the token itself.

When the token is in the `AwaitingTokenData` phase, the binding should also be `AwaitingTokendData` phase. When the token is n the `Ready` phase, the binding should eventually transition to `Injected` phase once the secret is successfully created.

You should also see the OAuth URL in the status of the binding object, if the OAuth URL is required (i.e. when the phase is `AwaitingTokenData`).