### PR TITLE
feat: Make it possible to specify the placeholders in the kustomize templates using env vars of the make targets.

### DIFF
--- a/config/k8s/config.yaml
+++ b/config/k8s/config.yaml
@@ -1,4 +1,4 @@
-sharedSecret: <SHARED_SECRET_VALUE>
+sharedSecret: ${SHARED_SECRET}
 serviceProviders:
 - type: GitHub
   clientId: "123"
@@ -6,4 +6,4 @@ serviceProviders:
 - type: Quay
   clientId: "456"
   clientSecret: "54"
-baseUrl: http://<OAUTH_HOST_VALUE>
+baseUrl: http://${OAUTH_HOST}

--- a/config/k8s/ingress.yaml
+++ b/config/k8s/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: oauth-ingress
 spec:
   rules:
-  - host: <OAUTH_HOST_VALUE>
+  - host: ${OAUTH_HOST}
     http:
       paths:
       - backend:

--- a/hack/replace_placeholders_and_deploy.sh
+++ b/hack/replace_placeholders_and_deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# This script copies the config directory containing the kustomize templates into a subdirectory under .tmp.
+# It then replaces the placeholders in those templates using envsubst, sets the images according to the SPIO_IMG
+# and SPIS_IMG env vars (as defined by the Makefile) and deploys.
+
+set -e
+
+# the path to the kustomize executable
+KUSTOMIZE=$1
+
+# the name of the deployment - only used as a part of the directory the templates are copied into
+DEPL_NAME=$2
+
+# The name of the kustomize overlay directory to apply
+OVERLAY=$3
+
+THIS_DIR="$(dirname "$(realpath "$0")")"
+TEMP_DIR="${THIS_DIR}/../.tmp/deployment_${DEPL_NAME}"
+
+OVERLAY_DIR="${TEMP_DIR}/${OVERLAY}"
+
+mkdir -p "${TEMP_DIR}"
+cp -r "${THIS_DIR}/../config/"* "${TEMP_DIR}"
+find "${TEMP_DIR}" -name '*.yaml' | while read -r f; do
+  tmp=$(mktemp)
+  envsubst > "$tmp" < "$f"
+  mv "$tmp" "$f"
+done
+
+CURDIR=$(pwd)
+
+cd "${OVERLAY_DIR}" || exit
+${KUSTOMIZE} edit set image quay.io/redhat-appstudio/service-provider-integration-operator="${SPIO_IMG}"
+${KUSTOMIZE} edit set image quay.io/redhat-appstudio/service-provider-integration-oauth="${SPIS_IMG}"
+${KUSTOMIZE} build . | kubectl apply -f -
+
+cd "${CURDIR}" || exit


### PR DESCRIPTION
### What does this PR do?
This PR makes two changes to how the kustomize templates are deployed using the Makefile.

1. They're no longer modified in-place but rather first copied into the .tmp directory
   so that deploying with some custom image doesn't modify the checked-in source code.
1. Before the templates are applied the placeholders in them are replaced using
   `envsubst`. This makes it possible to remain flexible with the deployments during
   the dev cycle (for which we can use the Makefile) and define a robust deployment
   template for use with infra-deployments overlays. 

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A

### How to test this PR?
With minikube, the following should use the default image (...:next) for the OAuth service image,
the custom image for the operator (...:tag), `spi.W.X.Y.Z.nip.io` for the OAuth host in both the
ingress and SPI configuration secret (where `W.X.Y.Z` is the output of `minikube ip`) and `blah`
as the shared secret value in the SPI configuration secret.


```
make deploy_minikube SPIO_IMG=quay.io/lkrejci/service-provider-integration-operator:my-tag SHARED_SECRET=blah
```

