### PR TITLE
fix: SVPI-55 avoid duplicates in jwt token scopes

### DIFF
--- a/integration_tests/serviceprovider_mock.go
+++ b/integration_tests/serviceprovider_mock.go
@@ -1,0 +1,62 @@
+package integrationtests
+
+import (
+	"context"
+
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestServiceProvider is an implementation of the serviceprovider.ServiceProvider interface that can be modified by
+// supplying custom implementations of each of the interface method. It provides dummy implementations of them, too, so
+// that no null pointer dereferences should occur under normal operation.
+type TestServiceProvider struct {
+	LookupTokenImpl       func(context.Context, client.Client, *api.SPIAccessTokenBinding) (*api.SPIAccessToken, error)
+	GetBaseUrlImpl        func() string
+	TranslateToScopesImpl func(permission api.Permission) []string
+	GetTypeImpl           func() api.ServiceProviderType
+	GetOauthEndpointImpl  func() string
+}
+
+func (t TestServiceProvider) LookupToken(ctx context.Context, cl client.Client, binding *api.SPIAccessTokenBinding) (*api.SPIAccessToken, error) {
+	if t.LookupTokenImpl == nil {
+		return nil, nil
+	}
+	return t.LookupTokenImpl(ctx, cl, binding)
+}
+
+func (t TestServiceProvider) GetBaseUrl() string {
+	if t.GetBaseUrlImpl == nil {
+		return "test-provider://"
+	}
+	return t.GetBaseUrlImpl()
+}
+
+func (t TestServiceProvider) TranslateToScopes(permission api.Permission) []string {
+	if t.TranslateToScopesImpl == nil {
+		return []string{}
+	}
+	return t.TranslateToScopesImpl(permission)
+}
+
+func (t TestServiceProvider) GetType() api.ServiceProviderType {
+	if t.GetTypeImpl == nil {
+		return "TestServiceProvider"
+	}
+	return t.GetTypeImpl()
+}
+
+func (t TestServiceProvider) GetOAuthEndpoint() string {
+	if t.GetOauthEndpointImpl == nil {
+		return ""
+	}
+	return t.GetOauthEndpointImpl()
+}
+
+func (t *TestServiceProvider) Reset() {
+	t.LookupTokenImpl = nil
+	t.GetBaseUrlImpl = nil
+	t.TranslateToScopesImpl = nil
+	t.GetTypeImpl = nil
+	t.GetOauthEndpointImpl = nil
+}

--- a/integration_tests/serviceprovider_mock.go
+++ b/integration_tests/serviceprovider_mock.go
@@ -1,3 +1,17 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package integrationtests
 
 import (

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -66,61 +66,7 @@ type IntegrationTest struct {
 
 var ITest IntegrationTest
 
-// TestServiceProvider is an implementation of the serviceprovider.ServiceProvider interface that can be modified by
-// supplying custom implementations of each of the interface method. It provides dummy implementations of them, too, so
-// that no null pointer dereferences should occur under normal operation.
-type TestServiceProvider struct {
-	LookupTokenImpl       func(context.Context, client.Client, *api.SPIAccessTokenBinding) (*api.SPIAccessToken, error)
-	GetBaseUrlImpl        func() string
-	TranslateToScopesImpl func(permission api.Permission) []string
-	GetTypeImpl           func() api.ServiceProviderType
-	GetOauthEndpointImpl  func() string
-}
-
 var _ serviceprovider.ServiceProvider = (*TestServiceProvider)(nil)
-
-func (t TestServiceProvider) LookupToken(ctx context.Context, cl client.Client, binding *api.SPIAccessTokenBinding) (*api.SPIAccessToken, error) {
-	if t.LookupTokenImpl == nil {
-		return nil, nil
-	}
-	return t.LookupTokenImpl(ctx, cl, binding)
-}
-
-func (t TestServiceProvider) GetBaseUrl() string {
-	if t.GetBaseUrlImpl == nil {
-		return "test-provider://"
-	}
-	return t.GetBaseUrlImpl()
-}
-
-func (t TestServiceProvider) TranslateToScopes(permission api.Permission) []string {
-	if t.TranslateToScopesImpl == nil {
-		return []string{}
-	}
-	return t.TranslateToScopesImpl(permission)
-}
-
-func (t TestServiceProvider) GetType() api.ServiceProviderType {
-	if t.GetTypeImpl == nil {
-		return "TestServiceProvider"
-	}
-	return t.GetTypeImpl()
-}
-
-func (t TestServiceProvider) GetOAuthEndpoint() string {
-	if t.GetOauthEndpointImpl == nil {
-		return ""
-	}
-	return t.GetOauthEndpointImpl()
-}
-
-func (t *TestServiceProvider) Reset() {
-	t.LookupTokenImpl = nil
-	t.GetBaseUrlImpl = nil
-	t.TranslateToScopesImpl = nil
-	t.GetTypeImpl = nil
-	t.GetOauthEndpointImpl = nil
-}
 
 // Returns a function that can be used as an implementation of the serviceprovider.ServiceProvider.LookupToken method
 // that just returns a freshly loaded version of the provided token. The token is a pointer to a pointer to the token

--- a/pkg/serviceprovider/serviceprovider.go
+++ b/pkg/serviceprovider/serviceprovider.go
@@ -112,7 +112,7 @@ func GetAllScopes(sp ServiceProvider, perms *api.Permissions) []string {
 		}
 	}
 
-	allScopes := make([]string, len(scopesSet))
+	allScopes := make([]string, 0)
 	for s, _ := range scopesSet {
 		allScopes = append(allScopes, s)
 	}

--- a/pkg/serviceprovider/serviceprovider.go
+++ b/pkg/serviceprovider/serviceprovider.go
@@ -113,7 +113,7 @@ func GetAllScopes(sp ServiceProvider, perms *api.Permissions) []string {
 	}
 
 	allScopes := make([]string, 0)
-	for s, _ := range scopesSet {
+	for s := range scopesSet {
 		allScopes = append(allScopes, s)
 	}
 	return allScopes

--- a/pkg/serviceprovider/serviceprovider.go
+++ b/pkg/serviceprovider/serviceprovider.go
@@ -100,13 +100,21 @@ func (f *Factory) FromRepoUrl(repoUrl string) (ServiceProvider, error) {
 // GetAllScopes is a helper method to translate all the provided permissions into a list of service-provided-specific
 // scopes.
 func GetAllScopes(sp ServiceProvider, perms *api.Permissions) []string {
-	allScopes := make([]string, len(perms.AdditionalScopes)+len(perms.Required))
+	scopesSet := make(map[string]bool)
 
-	allScopes = append(allScopes, perms.AdditionalScopes...)
-
-	for _, p := range perms.Required {
-		allScopes = append(allScopes, sp.TranslateToScopes(p)...)
+	for _, s := range perms.AdditionalScopes {
+		scopesSet[s] = true
 	}
 
+	for _, p := range perms.Required {
+		for _, s := range sp.TranslateToScopes(p) {
+			scopesSet[s] = true
+		}
+	}
+
+	allScopes := make([]string, len(scopesSet))
+	for s, _ := range scopesSet {
+		allScopes = append(allScopes, s)
+	}
 	return allScopes
 }

--- a/pkg/serviceprovider/serviceprovider_test.go
+++ b/pkg/serviceprovider/serviceprovider_test.go
@@ -1,0 +1,38 @@
+package serviceprovider
+
+import (
+	"testing"
+
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	integrationtests "github.com/redhat-appstudio/service-provider-integration-operator/integration_tests"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAllScopesUniqueValues(t *testing.T) {
+	sp := integrationtests.TestServiceProvider{
+		TranslateToScopesImpl: func(permission api.Permission) []string {
+			return []string{string(permission.Type), string(permission.Area)}
+		},
+	}
+	perms := &api.Permissions{
+		Required: []api.Permission{
+			{
+				Type: "a",
+				Area: "b",
+			},
+			{
+				Type: "a",
+				Area: "c",
+			},
+		},
+		AdditionalScopes: []string{"a", "b", "d", "e"},
+	}
+
+	scopes := GetAllScopes(sp, perms)
+
+	expected := []string{"a", "b", "c", "d", "e"}
+	for _, e := range expected {
+		assert.Contains(t, scopes, e)
+	}
+	assert.Len(t, scopes, len(expected))
+}

--- a/pkg/serviceprovider/serviceprovider_test.go
+++ b/pkg/serviceprovider/serviceprovider_test.go
@@ -1,3 +1,17 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package serviceprovider
 
 import (


### PR DESCRIPTION
### What does this PR do?
Avoid duplicate scopes in generated JWT token

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-55

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
operator image: `quay.io/mvala/spi-operator:svpi55-jwt`
1. create some valid `SPIAccessTokenBinding` like `kubectl apply -f samples/spiaccesstokenbinding.yaml`
2. check url in `SPIAccessToken` status `kubectl get spiaccesstoken  -o yaml`
3. copy `state` param from the url and decode with e.g. https://jwt.io/
4. you should not see any duplicates in `scopes` field of jwt token
