### PR TITLE
Replace the delete webhook on SPIAccessToken with a finalizer.

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -24,6 +24,8 @@ jobs:
         with:
           go-version: 1.16
       - name: Run tests
+        env:
+          GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT: 10s
         run: make test
       - name: Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -100,6 +100,8 @@ jobs:
             exit 1
           fi
       - name: Run Go Tests
+        env:
+          GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT: 10s
         run: |
           python -m pip install --upgrade pip yq
           make test

--- a/integration_tests/spiaccesstokencontroller_test.go
+++ b/integration_tests/spiaccesstokencontroller_test.go
@@ -17,6 +17,8 @@ package integrationtests
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
@@ -113,7 +115,16 @@ var _ = Describe("Create without token data", func() {
 		Expect(ITest.Client.Delete(ITest.Context, createdToken)).To(Succeed())
 	})
 
-	It("doesn't auto-create the token", func() {
+	It("sets up the finalizers", func() {
+		Eventually(func(g Gomega) {
+			token := &api.SPIAccessToken{}
+			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), token)).To(Succeed())
+			g.Expect(token.ObjectMeta.Finalizers).To(ContainElement("spi.appstudio.redhat.com/linked-bindings"))
+			g.Expect(token.ObjectMeta.Finalizers).To(ContainElement("spi.appstudio.redhat.com/token-storage"))
+		}).Should(Succeed())
+	})
+
+	It("doesn't auto-create the token data", func() {
 		accessToken := &api.SPIAccessToken{}
 		Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), accessToken)).To(Succeed())
 
@@ -182,9 +193,8 @@ var _ = Describe("Create without token data", func() {
 })
 
 var _ = Describe("Delete token", func() {
-	var createdBinding *api.SPIAccessTokenBinding
 	var createdToken *api.SPIAccessToken
-	bindingDeleted := false
+	tokenDeleteInProgress := false
 
 	BeforeEach(func() {
 		createdToken = &api.SPIAccessToken{
@@ -196,57 +206,95 @@ var _ = Describe("Delete token", func() {
 				ServiceProviderType: "TestServiceProvider",
 			},
 		}
-		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
-		createdBinding = &api.SPIAccessTokenBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-binding",
-				Namespace:    "default",
-			},
-			Spec: api.SPIAccessTokenBindingSpec{
-				Permissions: api.Permissions{},
-				RepoUrl:     "test-provider://",
-			},
-		}
 		Expect(ITest.Client.Create(ITest.Context, createdToken)).To(Succeed())
-		Expect(ITest.Client.Create(ITest.Context, createdBinding)).To(Succeed())
-
-		Expect(getLinkedToken(Default, createdBinding).UID).To(Equal(createdToken.UID))
 	})
 
 	AfterEach(func() {
-		binding := &api.SPIAccessTokenBinding{}
-		Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-
 		token := &api.SPIAccessToken{}
-		Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), token)).To(Succeed())
-
-		Expect(ITest.Client.Delete(ITest.Context, binding)).To(Succeed())
-
-		if bindingDeleted {
-			Eventually(func() error {
-				return ITest.Client.Delete(ITest.Context, token)
-			}).Should(Not(Succeed()))
+		if tokenDeleteInProgress {
+			err := ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), token)
+			if err == nil {
+				Eventually(func() error {
+					return ITest.Client.Delete(ITest.Context, token)
+				}).ShouldNot(Succeed())
+			} else {
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			}
 		} else {
+			Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), token)).To(Succeed())
 			Expect(ITest.Client.Delete(ITest.Context, token)).To(Succeed())
 		}
 	})
 
-	It("cannot happen as long as there are linked bindings", func() {
-		token := &api.SPIAccessToken{}
+	When("there are linked bindings", func() {
+		var createdBinding *api.SPIAccessTokenBinding
 
-		Eventually(func(g Gomega) {
+		BeforeEach(func() {
+			ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
+			createdBinding = &api.SPIAccessTokenBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-binding",
+					Namespace:    "default",
+				},
+				Spec: api.SPIAccessTokenBindingSpec{
+					Permissions: api.Permissions{},
+					RepoUrl:     "test-provider://",
+				},
+			}
+			Expect(ITest.Client.Create(ITest.Context, createdBinding)).To(Succeed())
+			Expect(getLinkedToken(Default, createdBinding).UID).To(Equal(createdToken.UID))
+		})
+
+		AfterEach(func() {
 			binding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: binding.Labels[opconfig.SPIAccessTokenLinkLabel],
-				Namespace: binding.Namespace}, token)).To(Succeed())
+			Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
+			Expect(ITest.Client.Delete(ITest.Context, binding)).To(Succeed())
+		})
+
+		It("doesn't happen", func() {
+			token := &api.SPIAccessToken{}
+			Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), token)).To(Succeed())
+
+			// the delete request should succeed
+			Expect(ITest.Client.Delete(ITest.Context, token)).To(Succeed())
+			tokenDeleteInProgress = true
+			// but the resource should not get deleted because of a finalizer that checks for the present bindings
+			time.Sleep(1 * time.Second)
+			Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(token), token)).To(Succeed())
+			Expect(token.ObjectMeta.Finalizers).To(ContainElement("spi.appstudio.redhat.com/linked-bindings"))
+		})
+	})
+
+	It("deletes token data from storage", func() {
+		// store the token data
+		loc, err := ITest.TokenStorage.Store(ITest.Context, createdToken, &api.Token{
+			AccessToken: "42",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// update the token with the location of the token data
+		token := &api.SPIAccessToken{}
+		Eventually(func(g Gomega) {
+			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), token)).To(Succeed())
+			token.Spec.DataLocation = loc
+			g.Expect(ITest.Client.Update(ITest.Context, token)).To(Succeed())
 		}).Should(Succeed())
 
-		// the delete request should succeed
+		// check that we can read the data from the storage
+		data, err := ITest.TokenStorage.Get(ITest.Context, token)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).NotTo(BeNil())
+
+		// delete the token
 		Expect(ITest.Client.Delete(ITest.Context, token)).To(Succeed())
-		// but the resource should not get deleted because of a finalizer that checks for the present bindings
-		time.Sleep(1 * time.Second)
-		bindingDeleted = true
-		Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(token), &api.SPIAccessToken{})).To(Succeed())
+		tokenDeleteInProgress = true
+
+		// test that the data disappears, too
+		Eventually(func(g Gomega) {
+			data, err := ITest.TokenStorage.Get(ITest.Context, token)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(data).To(BeNil())
+		}).Should(Succeed())
 	})
 })
 

--- a/webhooks/spiaccesstoken_webhook.go
+++ b/webhooks/spiaccesstoken_webhook.go
@@ -69,8 +69,6 @@ func (w *SPIAccessTokenWebhook) Handle(ctx context.Context, req wh.Request) wh.R
 			return wh.Errored(http.StatusBadRequest, err)
 		}
 		return w.handleUpdate(ctx, req, oldToken, token)
-	case adm.Delete:
-		return w.handleDelete(ctx, token)
 	}
 
 	return wh.Allowed("")
@@ -117,11 +115,4 @@ func (w *SPIAccessTokenWebhook) handleCreate(ctx context.Context, req wh.Request
 
 func (w *SPIAccessTokenWebhook) handleUpdate(ctx context.Context, req wh.Request, oldToken *api.SPIAccessToken, newToken *api.SPIAccessToken) wh.Response {
 	return w.handleCreate(ctx, req, newToken)
-}
-
-func (w *SPIAccessTokenWebhook) handleDelete(ctx context.Context, token *api.SPIAccessToken) wh.Response {
-	if err := w.TokenStorage.Delete(ctx, token); err != nil {
-		return wh.Denied(err.Error())
-	}
-	return wh.Allowed("")
 }


### PR DESCRIPTION
### What does this PR do?
`${TITLE}`

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-76

### How to test this PR?
(the steps assume that we are still storing the token data as secrets)
1. Create an `SPIAccessTokenBinding`
1. Go through the OAuth flow so that it is injected
1. Make note of the linked access token
1. Check that there are 2 secrets in the namespace - 1 owned by the binding and 1 owned by the token
1. Delete the binding
1. Delete the token
1. Both secrets should disappear

