### PR TITLE
build: Push images on git tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,8 @@ on:
   push:
     branches:
       - main
-      - v0.*
+    tags:
+      - 'v*'
 
 jobs:
 
@@ -30,7 +31,20 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            quay.io/redhat-appstudio/service-provider-integration-operator
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+            type=raw,value=next,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Login to docker.io
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -38,53 +52,15 @@ jobs:
           registry: docker.io
       - name: Login to quay.io
         uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
           registry: quay.io
-      - name: Docker Build & Push
-        uses: docker/build-push-action@v1.1.0
+      - name: Build and push
+        uses: docker/build-push-action@v2
         with:
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-          registry: quay.io
-          repository: redhat-appstudio/service-provider-integration-operator
-          dockerfile: Dockerfile
-          tags: next
-          tag_with_sha: true
-
-  build-bundle-images:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout devworkspace-operator source code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-      - name: Install CLI tools from GitHub
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          source: "github"
-          github_pat: ${{ github.token }}
-          operator-sdk: "1.14.0"
-          kustomize: "4.4.1"
-      - name: Get the 7-digit commit sha
-        id: get_sha
-        run: echo ::set-output name=git_sha::sha-$(git rev-parse --short=7 HEAD)
-      - name: Login to quay.io
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-          registry: quay.io
-      - name: Docker Build & Push - application-service Operator Bundle Image - next tag
-        run: make bundle bundle-build bundle-push
-      - name: Docker Build & Push - application-service Operator Catalog Image - next tag
-        run: make catalog-build catalog-push
-      - name: Docker Build & Push - application-service Operator Bundle Image - SHA tag
-        run: TAG_NAME=${{ steps.get_sha.outputs.git_sha }} make bundle bundle-build bundle-push
-      - name: Docker Build & Push - application-service Operator Catalog Image - SHA tag
-        run: TAG_NAME=${{ steps.get_sha.outputs.git_sha }} make catalog-build catalog-push
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### What does this PR do?
 - added ability to build images on git tag pushes.
 - removed OLM images build 

Such kind of image tags would be made 
on git tag
```
  quay.io/redhat-appstudio/service-provider-integration-operator:0.7.2
  quay.io/redhat-appstudio/service-provider-integration-operator:sha-922e4d7
  quay.io/redhat-appstudio/service-provider-integration-operator:latest
```

on commit to the main branch
```
  quay.io/redhat-appstudio/service-provider-integration-operator:next
  quay.io/redhat-appstudio/service-provider-integration-operator:sha-922e4d7
```
### Screenshot/screencast of this PR
n/a


### What issues does this PR fix or reference?
n/a


### How to test this PR?
- `git tag xxx && git push origin --tags`
- image build github action should be triggered