### PR TITLE
fix: Guard against nil transport in http client

### DIFF
--- a/pkg/serviceprovider/serviceprovider.go
+++ b/pkg/serviceprovider/serviceprovider.go
@@ -101,9 +101,14 @@ func (f *Factory) FromRepoUrl(repoUrl string) (ServiceProvider, error) {
 }
 
 func AuthenticatingHttpClient(cl *http.Client) *http.Client {
+	transport := cl.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
 	return &http.Client{
 		Transport: httptransport.ExaminingRoundTripper{
-			RoundTripper: httptransport.AuthenticatingRoundTripper{RoundTripper: cl.Transport},
+			RoundTripper: httptransport.AuthenticatingRoundTripper{RoundTripper: transport},
 			Examiner: httptransport.RoundTripExaminerFunc(func(request *http.Request, response *http.Response) error {
 				return sperrors.FromHttpStatusCode(response.StatusCode)
 			}),


### PR DESCRIPTION
### What does this PR do?
Don't assume non-nil transport. nil means "default" in the http client, so use that if we don't find an explicit one in the existing client.
