### PR TITLE
feat: add ability to use repo url in quay binding without https

### DIFF
--- a/pkg/serviceprovider/quay/quay.go
+++ b/pkg/serviceprovider/quay/quay.go
@@ -114,7 +114,7 @@ type quayProbe struct{}
 var _ serviceprovider.Probe = (*quayProbe)(nil)
 
 func (q quayProbe) Examine(_ *http.Client, url string) (string, error) {
-	if strings.HasPrefix(url, "https://quay.io") {
+	if strings.HasPrefix(url, "https://quay.io") || strings.HasPrefix(url, "quay.io") {
 		return "https://quay.io", nil
 	} else {
 		return "", nil

--- a/pkg/serviceprovider/quay/quay_test.go
+++ b/pkg/serviceprovider/quay/quay_test.go
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuayProbe_Examine(t *testing.T) {
+	probe := quayProbe{}
+	test := func(t *testing.T, url string, expectedMatch bool) {
+		baseUrl, err := probe.Examine(nil, url)
+		expectedBaseUrl := ""
+		if expectedMatch {
+			expectedBaseUrl = "https://quay.io"
+		}
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedBaseUrl, baseUrl)
+	}
+
+	test(t, "quay.io/name/repo", true)
+	test(t, "https://quay.io/name/repo", true)
+	test(t, "https://github.com/name/repo", false)
+	test(t, "github.com/name/repo", false)
+}

--- a/samples/binding-quay-without-protocol.yaml
+++ b/samples/binding-quay-without-protocol.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: SPIAccessTokenBinding
+metadata:
+  name: test-binding-quay-without-protocol
+  namespace: default
+spec:
+  permissions:
+    required:
+      - type: rw
+        area: repository
+  repoUrl: quay.io/repository/redhat_emp1/spi-test
+  secret:
+    type: kubernetes.io/basic-auth


### PR DESCRIPTION
Signed-off-by: Pavol Baran <pbaran@redhat.com>

### What does this PR do?
When a user created token binding for quay and specified repoUrl in format: quay.io/namespace/repo instead of https://quay.io/namespace/repo the binding would fail to recognize the service provider.
This PR fixes this problem.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
solves https://issues.redhat.com/browse/SVPI-109

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
To test locally on minikube (with ingress adon):

1. deploy operator with changes; wait for all components to be running
`make deploy_minikube SPIO_IMG=quay.io/pbaran/spio:SVPI-109-QUAY`

2. create a token binding that uses repo url in the format: quay.io/namespace/repo
`kubectl apply -f samples/binding-quay-without-protocol.yaml`

3. check that the binding has a linked access token in status
`TOKEN=$(kubectl get spiaccesstokenbindings test-binding-quay-without-protocol -o=jsonpath='{.status.linkedAccessTokenName}') && echo $TOKEN`

4. check that the access token has labels for service provider: quay
`kubectl describe spiaccesstoken $TOKEN`