### PR TITLE
spiaccesscheck cluster roles actually deployed

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -15,6 +15,8 @@ resources:
 - spiaccesstoken_viewer_role.yaml
 - spiaccesstokenbinding_editor_role.yaml
 - spiaccesstokenbinding_viewer_role.yaml
+- spiaccesscheck_editor_role.yaml
+- spiaccesscheck_viewer_role.yaml
 
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)

--- a/config/rbac/spiaccesscheck_editor_role.yaml
+++ b/config/rbac/spiaccesscheck_editor_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: spiaccesscheck-editor-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/config/rbac/spiaccesscheck_viewer_role.yaml
+++ b/config/rbac/spiaccesscheck_viewer_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: spiaccesscheck-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
 rules:
 - apiGroups:
   - appstudio.redhat.com


### PR DESCRIPTION
### What does this PR do?
SPIAccessCheck viewer and editor roles actually deployed

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-110

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
deploy with `make deploy` and try to create SPIAccessCheck with regular user in it's namespace with only editor and view roles. Before this patch, it was not possible.