### PR TITLE
Split single Github graphql request into two

### DIFF
--- a/pkg/serviceprovider/github/metadataprovider_test.go
+++ b/pkg/serviceprovider/github/metadataprovider_test.go
@@ -80,7 +80,10 @@ func TestMetadataProvider_Fetch(t *testing.T) {
 
 	tokenState := &TokenState{}
 	assert.NoError(t, json.Unmarshal(data.ServiceProviderState, tokenState))
-	assert.Equal(t, 3, len(tokenState.AccessibleRepos))
+	assert.Equal(t, 4, len(tokenState.AccessibleRepos))
+	val, ok := tokenState.AccessibleRepos["https://github.com/eclipse/manifest"]
+	assert.True(t, ok)
+	assert.Equal(t, RepositoryRecord{ViewerPermission: "READ"}, val)
 }
 
 func TestMetadataProvider_Fetch_fail(t *testing.T) {

--- a/pkg/serviceprovider/github/metadataprovider_test.go
+++ b/pkg/serviceprovider/github/metadataprovider_test.go
@@ -45,7 +45,7 @@ func TestMetadataProvider_Fetch(t *testing.T) {
 			} else {
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(allRepositoriesFakeResponse))),
+					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(repositoriesOwnerAffiliationsFakeResponse))),
 				}, nil
 			}
 		}),
@@ -94,7 +94,7 @@ func TestMetadataProvider_Fetch_fail(t *testing.T) {
 			} else {
 				return &http.Response{
 					StatusCode: 200,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(allRepositoriesFakeResponse))),
+					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(repositoriesOwnerAffiliationsFakeResponse))),
 				}, nil
 			}
 		}),

--- a/pkg/serviceprovider/github/queries.go
+++ b/pkg/serviceprovider/github/queries.go
@@ -16,8 +16,9 @@ package github
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sperrors "github.com/redhat-appstudio/service-provider-integration-operator/pkg/errors"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"

--- a/pkg/serviceprovider/github/queries.go
+++ b/pkg/serviceprovider/github/queries.go
@@ -16,9 +16,8 @@ package github
 
 import (
 	"context"
-	"strconv"
-
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strconv"
 
 	sperrors "github.com/redhat-appstudio/service-provider-integration-operator/pkg/errors"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"
@@ -89,7 +88,8 @@ func (r *AllAccessibleRepos) FetchAll(ctx context.Context, client *graphql.Clien
 	if err := _fetchAll(r, ctx, client, allAccessibleOwnerAffiliationsReposQuery, state); err != nil {
 		return err
 	}
-
+	lg := log.FromContext(ctx)
+	lg.Info("_fetchAll state.AccessibleRepos.len=" + strconv.Itoa(len(state.AccessibleRepos)))
 	return nil
 }
 
@@ -109,8 +109,6 @@ func _fetchAll(r *AllAccessibleRepos, ctx context.Context, client *graphql.Clien
 			state.AccessibleRepos[RepositoryUrl(node.Url)] = RepositoryRecord{ViewerPermission: ViewerPermission(node.ViewerPermission)}
 		}
 	})
-	//TODO how to do lg.Debug ?
-	lg.Info("_fetchAll state.AccessibleRepos.len=" + strconv.Itoa(len(state.AccessibleRepos)))
 	if err != nil {
 
 		lg.Error(err, "Error in FetchAll", "request", request)


### PR DESCRIPTION
### What does this PR do?
Since a single request might lead to some sort of timeouts or other errors it makes sense to separate it into two independent and merge results in runtime.

### Screenshot/screencast of this PR

n/a

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-133


### How to test this PR?
1. deploy `quay.io/skabashn/service-provider-integration-operator:SVPI-133_2022_06_06__16_03_37` operator image
2. Create SpiAccessTokenBinding 
3. Upload `Sahil Budhwar'` Github token.
4. SpiAccessTokeToken has to have metadata.
5. Binding should work and token should be injected as a secret 
