### PR TITLE
Use https protocol where it possible

### DIFF
--- a/bundle/manifests/service-provider-integration-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/service-provider-integration-operator.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ spec:
                 - /manager
                 env:
                 - name: SPI_URL
-                  value: http://service-provider-integration-api
+                  value: https://service-provider-integration-api
                 image: quay.io/redhat-appstudio/service-provider-integration-operator:next
                 livenessProbe:
                   httpGet:

--- a/config/k8s/config.yaml
+++ b/config/k8s/config.yaml
@@ -6,4 +6,4 @@ serviceProviders:
 - type: Quay
   clientId: "456"
   clientSecret: "54"
-baseUrl: http://${OAUTH_HOST}
+baseUrl: https://${OAUTH_HOST}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
         - --leader-elect
         env:
         - name: SPI_URL
-          value: http://service-provider-integration-api
+          value: https://service-provider-integration-api
         image: quay.io/redhat-appstudio/service-provider-integration-operator:next
         name: manager
         securityContext:

--- a/config/openshift-example/config.yaml
+++ b/config/openshift-example/config.yaml
@@ -6,4 +6,4 @@ serviceProviders:
   - type: Quay
     clientId: "456"
     clientSecret: "54"
-baseUrl: http://${OAUTH_HOST}
+baseUrl: https://${OAUTH_HOST}

--- a/pkg/spi-shared/httptransport/auth_test.go
+++ b/pkg/spi-shared/httptransport/auth_test.go
@@ -27,7 +27,7 @@ import (
 func TestAuthenticatingRoundTripper_RoundTrip(t *testing.T) {
 	ctx := WithBearerToken(context.TODO(), "token")
 
-	req, err := http.NewRequestWithContext(ctx, "GET", "http://over.the.rainbow", strings.NewReader(""))
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://over.the.rainbow", strings.NewReader(""))
 	assert.NoError(t, err)
 
 	roundtripProcessed := false

--- a/pkg/spi-shared/httptransport/examine_test.go
+++ b/pkg/spi-shared/httptransport/examine_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestExaminingRoundTripper_RoundTrip(t *testing.T) {
-	req, err := http.NewRequest("GET", "http://over.the.rainbow", strings.NewReader(""))
+	req, err := http.NewRequest("GET", "https://over.the.rainbow", strings.NewReader(""))
 	assert.NoError(t, err)
 
 	examinerCalled := false


### PR DESCRIPTION
### What does this PR do?
Use HTTPS protocol where it is possible

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
After the https://github.com/redhat-appstudio/service-provider-integration-oauth/pull/92 OAuth service is use HTTPS only cookies. This pr aligns configuration with the requirement to use HTTPS where possible.


### How to test this PR?
n/a
