### PR TITLE
Fix for quay binding with rw permissions that fails to match the token 

### DIFF
--- a/pkg/serviceprovider/quay/state.go
+++ b/pkg/serviceprovider/quay/state.go
@@ -214,7 +214,7 @@ func oauthRepositoryRecord(ctx context.Context, cl *http.Client, repository stri
 func hasRepoRead(ctx context.Context, cl *http.Client, repository string, token string) (bool, *string, error) {
 	url := "https://quay.io/api/v1/repository/" + repository
 
-	resp, err := doQuayRequest(ctx, cl, url, token, "GET", nil)
+	resp, err := doQuayRequest(ctx, cl, url, token, "GET", nil, "")
 	if err != nil {
 		return false, nil, err
 	}
@@ -268,7 +268,7 @@ func hasRepoWrite(ctx context.Context, cl *http.Client, repository string, token
 	}
 	data := strings.NewReader(`{"description": ` + val + `}`)
 
-	resp, err := doQuayRequest(ctx, cl, url, token, "PUT", data)
+	resp, err := doQuayRequest(ctx, cl, url, token, "PUT", data, "application/json")
 	if err != nil {
 		return false, err
 	}
@@ -300,7 +300,7 @@ func hasRepoCreate(ctx context.Context, cl *http.Client, repository string, toke
 
 	lg.Info("asking quay API")
 
-	resp, err := doQuayRequest(ctx, cl, url, token, "POST", data)
+	resp, err := doQuayRequest(ctx, cl, url, token, "POST", data, "application/json")
 	if err != nil {
 		return false, err
 	}
@@ -324,7 +324,7 @@ func hasOrgAdmin(ctx context.Context, cl *http.Client, organization string, toke
 }
 
 func isSuccessfulRequest(ctx context.Context, cl *http.Client, url string, token string) (bool, error) {
-	resp, err := doQuayRequest(ctx, cl, url, token, "GET", nil)
+	resp, err := doQuayRequest(ctx, cl, url, token, "GET", nil, "")
 	if err != nil {
 		return false, err
 	}
@@ -335,7 +335,7 @@ func isSuccessfulRequest(ctx context.Context, cl *http.Client, url string, token
 	return resp.StatusCode == 200, nil
 }
 
-func doQuayRequest(ctx context.Context, cl *http.Client, url string, token string, method string, body io.Reader) (*http.Response, error) {
+func doQuayRequest(ctx context.Context, cl *http.Client, url string, token string, method string, body io.Reader, contentHeader string) (*http.Response, error) {
 	lg := log.FromContext(ctx, "url", url)
 
 	lg.Info("asking quay API")
@@ -346,8 +346,8 @@ func doQuayRequest(ctx context.Context, cl *http.Client, url string, token strin
 		return nil, err
 	}
 
-	if body != nil {
-		req.Header.Add("Content-Type", "application/json")
+	if contentHeader != "" {
+		req.Header.Set("Content-Type", contentHeader)
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	resp, err := cl.Do(req)

--- a/pkg/serviceprovider/quay/state.go
+++ b/pkg/serviceprovider/quay/state.go
@@ -346,6 +346,9 @@ func doQuayRequest(ctx context.Context, cl *http.Client, url string, token strin
 		return nil, err
 	}
 
+	if body != nil {
+		req.Header.Add("Content-Type", "application/json")
+	}
 	req.Header.Add("Authorization", "Bearer "+token)
 	resp, err := cl.Do(req)
 	if err != nil {

--- a/pkg/serviceprovider/quay/state_test.go
+++ b/pkg/serviceprovider/quay/state_test.go
@@ -292,3 +292,30 @@ func TestSplitToOrganizationAndRepositoryAndVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestDoQuayRequest(t *testing.T) {
+	test := func(url, token, method, body, header string) {
+		httpClient := http.Client{
+			Transport: util.FakeRoundTrip(func(r *http.Request) (*http.Response, error) {
+				if r.URL.String() == url {
+					assert.Equal(t, "Bearer "+token, r.Header.Get("Authorization"))
+					assert.Equal(t, header, r.Header.Get("Content-Type"))
+					assert.Equal(t, method, r.Method)
+					return &http.Response{StatusCode: 200}, nil
+				}
+				assert.Fail(t, "unexpected request", "url", r.URL)
+				return nil, nil
+			}),
+		}
+		resp, err := doQuayRequest(context.TODO(), &httpClient, url, token, method, strings.NewReader(body), header)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+	}
+
+	t.Run("empty header", func(t *testing.T) {
+		test("http://test.com", "token", "GET", "body", "")
+	})
+	t.Run("application/json header", func(t *testing.T) {
+		test("http://test.com/123", "token123", "POST", "body123", "application/json ")
+	})
+}


### PR DESCRIPTION
Signed-off-by: Pavol Baran <pbaran@redhat.com>

### What does this PR do?
Adds content-type=application/json header to requests made to the Quay API analyzing the access tokens scopes. This fixes an issue where the Quay API responds with HTTP 400 and error message about missing JSON body. This issue resulted in missing `repo:write` scope in spiaccesstoken state which cause error in spiaccesstokenbinding if permissions were set as `rw` 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->
Correct state of spiaccesstoken and spiaccesstokenbinding after oauth flow.

spiaccesstokenbinding
```yaml
spec:                                                                                                                                                          
  permissions:                                                                                                                                                 
    required:                                                                                                                                                  
    - area: repository                                                                                                                                         
      type: rw                                                                                                                                                 
  repoUrl: quay.io/repository/testingorganization/che-server                                                                                                   
  secret:                                                                                                                                                      
    fields: {}                                                                                                                                                 
    type: kubernetes.io/basic-auth                                                                                                                             
status:                                                                                                                                                        
  linkedAccessTokenName: generated-spi-access-token-lljwf                                                                                                      
  oAuthUrl: ""                                                                                                                                                 
  phase: Injected                                                                                                                                              
  syncedObjectRef:                                                                                                                                             
    apiVersion: v1                                                                                                                                             
    kind: Secret                                                                                                                                               
    name: test-binding-quay-without-protocol-secret-jh6wd 
```

spiaccesstoken
```yaml
spec:                                                                                                                                                          
  permissions:                                                                                                                                                 
    required:                                                                                                                                                  
    - area: repository                                                                                                                                         
      type: rw                                                                                                                                                 
  serviceProviderUrl: https://quay.io                                                                                                                          
status:                                                                                                                                                        
  errorMessage: ""                                                                                                                                             
  errorReason: ""                                                                                                                                              
  oAuthUrl: ""                                                                                                                                                 
  phase: Ready                                                                                                                                                 
  tokenMetadata:                                                                                                                                               
    lastRefreshTime: 1654697231                                                                                                                                
    serviceProviderState: eyJSZXBvc2l0b3JpZXMiOnsidGVzdGluZ29yZ2FuaXphdGlvbi9jaGUtc2VydmVyIjp7Ikxhc3RSZWZyZXNoVGltZSI6MTY1NDY5NzIzNCwiUG9zc2Vzc2VkU2NvcGVzIjpbI
nJlcG86cmVhZCIsInB1bGwiLCJyZXBvOndyaXRlIiwicHVzaCJdfX0sIk9yZ2FuaXphdGlvbnMiOnsidGVzdGluZ29yZ2FuaXphdGlvbiI6eyJMYXN0UmVmcmVzaFRpbWUiOjE2NTQ2OTcyMzIsIlBvc3Nlc3Nl
ZFNjb3BlcyI6W119fX0=                                                                                                                                           
    userId: ""                                                                                                                                                 
    username: $oauthtoken  
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
fixes https://issues.redhat.com/browse/SVPI-136

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
1. deploy operator with changes and configure oauth credentials; wait for all components to be running
` make deploy_minikube SPIO_IMG=quay.io/pbaran/spio:SVPI-136-QUAY`

2. create a token binding with repository `rw` permissions and with repo URL to which you have pull and push privileges, such as: `kubectl apply -f samples/binding-quay-without-protocol.yaml`

3. go through the OAuth flow

4. check that the bindings `status.phase` is Injected

5. Try different varieties of bindings such as: binding with repoUrl that (does not) contains `https://` or binding with only `r` permissions