### PR TITLE
initial APIResourceSchema and APIExport for KCP

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,7 +57,9 @@ jobs:
           echo "$HOME/bin" >> $GITHUB_PATH
       - name: Install kcp tooling
         run: |
-          git clone https://github.com/kcp-dev/kcp ~/kcp && cd ~/kcp && make install
+          git clone https://github.com/kcp-dev/kcp ~/kcp
+          cd ~/kcp
+          WHAT=./cmd/kubectl-kcp make install
       - name: Cache go modules
         id: cache-mod
         uses: actions/cache@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,6 +55,9 @@ jobs:
           mkdir -p ~/bin
           cp ~/cache/operator-sdk-${OPERATOR_SDK_VERSION} ~/bin/operator-sdk
           echo "$HOME/bin" >> $GITHUB_PATH
+      - name: Install kcp tooling
+        run: |
+          git clone https://github.com/kcp-dev/kcp ~/kcp && cd ~/kcp && make install
       - name: Cache go modules
         id: cache-mod
         uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,11 @@ help: ## Display this help.
 
 ##@ Development
 
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: controller-gen manifests-kcp ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+
+manifests-kcp:	## Generate KCP APIResourceSchema from CRDs
+	hack/generate-kcp-api.sh
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,9 @@ help: ## Display this help.
 
 ##@ Development
 
-manifests: controller-gen manifests-kcp ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(MAKE) manifests-kcp
 
 manifests-kcp:	## Generate KCP APIResourceSchema from CRDs
 	hack/generate-kcp-api.sh

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ The image being pushed can again be modified using the environment variable:
 SPIO_IMG=quay.io/acme/spio:42 make docker-push
 ```
 
+### KCP
+We generate `APIResourceSchema`s and `APIExport` for KCP from our CRDs using `./hack/generate-kcp-api.sh` script or `make manifests-kcp`.
+These have to be updated on every CRD change and committed. `APIResourceSchema` is immutable in KCP, so we version it by putting datetime as a name prefix.
+
+
 ## Configuration
 
 It is expected by the Kustomize deployment that this configuration lives in a Secret in the same namespaces as SPI.

--- a/config/kcp/apiexport_spi.yaml
+++ b/config/kcp/apiexport_spi.yaml
@@ -1,0 +1,12 @@
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: spi
+spec:
+  latestResourceSchemas:
+    - 2022-06-09-17-22.spiaccesschecks.appstudio.redhat.com
+    - 2022-06-09-17-22.spiaccesstokenbindings.appstudio.redhat.com
+    - 2022-06-09-17-22.spiaccesstokendataupdates.appstudio.redhat.com
+    - 2022-06-09-17-22.spiaccesstokens.appstudio.redhat.com

--- a/config/kcp/apiexport_spi.yaml
+++ b/config/kcp/apiexport_spi.yaml
@@ -7,7 +7,7 @@ metadata:
   name: spi
 spec:
   latestResourceSchemas:
-    - v202206091739.spiaccesschecks.appstudio.redhat.com
-    - v202206091739.spiaccesstokenbindings.appstudio.redhat.com
-    - v202206091739.spiaccesstokendataupdates.appstudio.redhat.com
-    - v202206091739.spiaccesstokens.appstudio.redhat.com
+    - v202206091758.spiaccesschecks.appstudio.redhat.com
+    - v202206091758.spiaccesstokenbindings.appstudio.redhat.com
+    - v202206091758.spiaccesstokendataupdates.appstudio.redhat.com
+    - v202206091758.spiaccesstokens.appstudio.redhat.com

--- a/config/kcp/apiexport_spi.yaml
+++ b/config/kcp/apiexport_spi.yaml
@@ -6,7 +6,7 @@ metadata:
   name: spi
 spec:
   latestResourceSchemas:
-    - 2022-06-09-17-22.spiaccesschecks.appstudio.redhat.com
-    - 2022-06-09-17-22.spiaccesstokenbindings.appstudio.redhat.com
-    - 2022-06-09-17-22.spiaccesstokendataupdates.appstudio.redhat.com
-    - 2022-06-09-17-22.spiaccesstokens.appstudio.redhat.com
+    - 2022-06-09-15-50.spiaccesschecks.appstudio.redhat.com
+    - 2022-06-09-15-50.spiaccesstokenbindings.appstudio.redhat.com
+    - 2022-06-09-15-50.spiaccesstokendataupdates.appstudio.redhat.com
+    - 2022-06-09-15-50.spiaccesstokens.appstudio.redhat.com

--- a/config/kcp/apiexport_spi.yaml
+++ b/config/kcp/apiexport_spi.yaml
@@ -7,7 +7,7 @@ metadata:
   name: spi
 spec:
   latestResourceSchemas:
-    - v202206091758.spiaccesschecks.appstudio.redhat.com
-    - v202206091758.spiaccesstokenbindings.appstudio.redhat.com
-    - v202206091758.spiaccesstokendataupdates.appstudio.redhat.com
-    - v202206091758.spiaccesstokens.appstudio.redhat.com
+    - v202206100727.spiaccesschecks.appstudio.redhat.com
+    - v202206100727.spiaccesstokenbindings.appstudio.redhat.com
+    - v202206100727.spiaccesstokendataupdates.appstudio.redhat.com
+    - v202206100727.spiaccesstokens.appstudio.redhat.com

--- a/config/kcp/apiexport_spi.yaml
+++ b/config/kcp/apiexport_spi.yaml
@@ -6,7 +6,7 @@ metadata:
   name: spi
 spec:
   latestResourceSchemas:
-    - 2022-06-09-15-50.spiaccesschecks.appstudio.redhat.com
-    - 2022-06-09-15-50.spiaccesstokenbindings.appstudio.redhat.com
-    - 2022-06-09-15-50.spiaccesstokendataupdates.appstudio.redhat.com
-    - 2022-06-09-15-50.spiaccesstokens.appstudio.redhat.com
+    - 202206091552.spiaccesschecks.appstudio.redhat.com
+    - 202206091552.spiaccesstokenbindings.appstudio.redhat.com
+    - 202206091552.spiaccesstokendataupdates.appstudio.redhat.com
+    - 202206091552.spiaccesstokens.appstudio.redhat.com

--- a/config/kcp/apiexport_spi.yaml
+++ b/config/kcp/apiexport_spi.yaml
@@ -1,12 +1,13 @@
 # This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
 # Please do not modify!
+
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
   name: spi
 spec:
   latestResourceSchemas:
-    - v202206091559.spiaccesschecks.appstudio.redhat.com
-    - v202206091559.spiaccesstokenbindings.appstudio.redhat.com
-    - v202206091559.spiaccesstokendataupdates.appstudio.redhat.com
-    - v202206091559.spiaccesstokens.appstudio.redhat.com
+    - v202206091739.spiaccesschecks.appstudio.redhat.com
+    - v202206091739.spiaccesstokenbindings.appstudio.redhat.com
+    - v202206091739.spiaccesstokendataupdates.appstudio.redhat.com
+    - v202206091739.spiaccesstokens.appstudio.redhat.com

--- a/config/kcp/apiexport_spi.yaml
+++ b/config/kcp/apiexport_spi.yaml
@@ -6,7 +6,7 @@ metadata:
   name: spi
 spec:
   latestResourceSchemas:
-    - 202206091552.spiaccesschecks.appstudio.redhat.com
-    - 202206091552.spiaccesstokenbindings.appstudio.redhat.com
-    - 202206091552.spiaccesstokendataupdates.appstudio.redhat.com
-    - 202206091552.spiaccesstokens.appstudio.redhat.com
+    - v202206091559.spiaccesschecks.appstudio.redhat.com
+    - v202206091559.spiaccesstokenbindings.appstudio.redhat.com
+    - v202206091559.spiaccesstokendataupdates.appstudio.redhat.com
+    - v202206091559.spiaccesstokens.appstudio.redhat.com

--- a/config/kcp/apiresourceschema_spi.yaml
+++ b/config/kcp/apiresourceschema_spi.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 202206091552.spiaccesschecks.appstudio.redhat.com
+  name: v202206091559.spiaccesschecks.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -104,7 +104,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 202206091552.spiaccesstokenbindings.appstudio.redhat.com
+  name: v202206091559.spiaccesstokenbindings.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -295,7 +295,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 202206091552.spiaccesstokendataupdates.appstudio.redhat.com
+  name: v202206091559.spiaccesstokendataupdates.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -350,7 +350,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 202206091552.spiaccesstokens.appstudio.redhat.com
+  name: v202206091559.spiaccesstokens.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:

--- a/config/kcp/apiresourceschema_spi.yaml
+++ b/config/kcp/apiresourceschema_spi.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091559.spiaccesschecks.appstudio.redhat.com
+  name: v202206091739.spiaccesschecks.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -104,7 +104,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091559.spiaccesstokenbindings.appstudio.redhat.com
+  name: v202206091739.spiaccesstokenbindings.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -295,7 +295,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091559.spiaccesstokendataupdates.appstudio.redhat.com
+  name: v202206091739.spiaccesstokendataupdates.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -350,7 +350,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091559.spiaccesstokens.appstudio.redhat.com
+  name: v202206091739.spiaccesstokens.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:

--- a/config/kcp/apiresourceschema_spi.yaml
+++ b/config/kcp/apiresourceschema_spi.yaml
@@ -1,0 +1,482 @@
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: 2022-06-09-17-22.spiaccesschecks.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: SPIAccessCheck
+    listKind: SPIAccessCheckList
+    plural: spiaccesschecks
+    singular: spiaccesscheck
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      description: SPIAccessCheck is the Schema for the spiaccesschecks API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SPIAccessCheckSpec defines the desired state of SPIAccessCheck
+          properties:
+            permissions:
+              description: Permissions is a collection of operator-defined permissions
+                (which are translated to service-provider-specific scopes) and potentially
+                additional service-provider-specific scopes that are not covered by
+                the operator defined abstraction. The permissions are used in SPIAccessTokenBinding
+                objects to express the requirements on the tokens as well as in the
+                SPIAccessToken objects to express the "capabilities" of the token.
+              properties:
+                additionalScopes:
+                  items:
+                    type: string
+                  type: array
+                required:
+                  items:
+                    description: Permission is an element of Permissions and express
+                      a requirement on the service provider scopes in an agnostic
+                      manner.
+                    properties:
+                      area:
+                        description: Area express the "area" in the service provider
+                          scopes to which the permission is required.
+                        type: string
+                      type:
+                        description: Type is the type of the permission required
+                        type: string
+                    required:
+                    - area
+                    - type
+                    type: object
+                  type: array
+              type: object
+            repoUrl:
+              type: string
+          required:
+          - repoUrl
+          type: object
+        status:
+          description: SPIAccessCheckStatus defines the observed state of SPIAccessCheck
+          properties:
+            accessibility:
+              type: string
+            accessible:
+              type: boolean
+            errorMessage:
+              type: string
+            errorReason:
+              type: string
+            repoType:
+              type: string
+            serviceProvider:
+              description: ServiceProviderType defines the set of supported service
+                providers
+              type: string
+          required:
+          - accessibility
+          - accessible
+          - repoType
+          - serviceProvider
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: 2022-06-09-17-22.spiaccesstokenbindings.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: SPIAccessTokenBinding
+    listKind: SPIAccessTokenBindingList
+    plural: spiaccesstokenbindings
+    singular: spiaccesstokenbinding
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      description: SPIAccessTokenBinding is the Schema for the spiaccesstokenbindings
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SPIAccessTokenBindingSpec defines the desired state of SPIAccessTokenBinding
+          properties:
+            permissions:
+              description: Permissions is a collection of operator-defined permissions
+                (which are translated to service-provider-specific scopes) and potentially
+                additional service-provider-specific scopes that are not covered by
+                the operator defined abstraction. The permissions are used in SPIAccessTokenBinding
+                objects to express the requirements on the tokens as well as in the
+                SPIAccessToken objects to express the "capabilities" of the token.
+              properties:
+                additionalScopes:
+                  items:
+                    type: string
+                  type: array
+                required:
+                  items:
+                    description: Permission is an element of Permissions and express
+                      a requirement on the service provider scopes in an agnostic
+                      manner.
+                    properties:
+                      area:
+                        description: Area express the "area" in the service provider
+                          scopes to which the permission is required.
+                        type: string
+                      type:
+                        description: Type is the type of the permission required
+                        type: string
+                    required:
+                    - area
+                    - type
+                    type: object
+                  type: array
+              type: object
+            repoUrl:
+              type: string
+            secret:
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations is the keys and values that the create
+                    secret should be annotated with.
+                  type: object
+                fields:
+                  description: Fields specifies the mapping from the token record
+                    fields to the keys in the secret data.
+                  properties:
+                    expiredAfter:
+                      description: ExpiredAfter specifies the data key in which the
+                        expiry date of the token should be stored.
+                      type: string
+                    name:
+                      description: Name specifies the data key in which the name of
+                        the token record should be stored.
+                      type: string
+                    scopes:
+                      description: Scopes specifies the data key in which the comma-separated
+                        list of token scopes should be stored.
+                      type: string
+                    serviceProviderUrl:
+                      description: ServiceProviderUrl specifies the data key in which
+                        the url of the service provider should be stored.
+                      type: string
+                    serviceProviderUserId:
+                      description: ServiceProviderUserId specifies the data key in
+                        which the url of the user id used in the service provider
+                        should be stored.
+                      type: string
+                    serviceProviderUserName:
+                      description: ServiceProviderUserName specifies the data key
+                        in which the url of the user name used in the service provider
+                        should be stored.
+                      type: string
+                    token:
+                      description: Token specifies the data key in which the token
+                        should be stored.
+                      type: string
+                    userId:
+                      description: UserId specifies the data key in which the user
+                        id as known to the SPI should be stored (note that this is
+                        usually different from ServiceProviderUserId, because the
+                        former is usually a kubernetes user, while the latter is some
+                        arbitrary ID used by the service provider which might or might
+                        not correspond to the Kubernetes user id).
+                      type: string
+                  type: object
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: Labels contains the labels that the created secret
+                    should be labeled with.
+                  type: object
+                name:
+                  description: Name is the name of the secret to be created. If it
+                    is not defined a random name based on the name of the binding
+                    is used.
+                  type: string
+                type:
+                  description: Type is the type of the secret to be created. If left
+                    empty, the default type used in the cluster is assumed (typically
+                    Opaque). The type of the secret defines the automatic mapping
+                    of the token record fields to keys in the secret data according
+                    to the documentation https://kubernetes.io/docs/concepts/configuration/secret/#secret-types.
+                    Only kubernetes.io/service-account-token, kubernetes.io/dockercfg,
+                    kubernetes.io/dockerconfigjson and kubernetes.io/basic-auth are
+                    supported. All other secret types need to have their mapping specified
+                    manually using the Fields.
+                  type: string
+              type: object
+          required:
+          - permissions
+          - repoUrl
+          - secret
+          type: object
+        status:
+          description: SPIAccessTokenBindingStatus defines the observed state of SPIAccessTokenBinding
+          properties:
+            errorMessage:
+              type: string
+            errorReason:
+              type: string
+            linkedAccessTokenName:
+              type: string
+            oAuthUrl:
+              type: string
+            phase:
+              type: string
+            syncedObjectRef:
+              properties:
+                apiVersion:
+                  description: ApiVersion is the api version of the object with the
+                    injected data.
+                  type: string
+                kind:
+                  description: Kind is the kind of the object with the injected data.
+                  type: string
+                name:
+                  description: Name is the name of the object with the injected data.
+                    This always lives in the same namespace as the AccessTokenSecret
+                    object.
+                  type: string
+              required:
+              - apiVersion
+              - kind
+              - name
+              type: object
+          required:
+          - linkedAccessTokenName
+          - oAuthUrl
+          - phase
+          - syncedObjectRef
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: 2022-06-09-17-22.spiaccesstokendataupdates.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: SPIAccessTokenDataUpdate
+    listKind: SPIAccessTokenDataUpdateList
+    plural: spiaccesstokendataupdates
+    singular: spiaccesstokendataupdate
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      description: SPIAccessTokenDataUpdate is a special CRD that advertises to the
+        controller in the Kubernetes cluster that there has been an update of the
+        data in the token storage. Because token storage is out-of-cluster, updates
+        to it are not registered by the controllers. This CRD serves as a "trigger"
+        for reconciliation of the SPIAccessToken after the data has been updated in
+        the token storage. The caller that updates the data in the token storage is
+        responsible for creating an object pointing to the SPIAccessToken that should
+        have been affected.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SPIAccessTokenDataUpdateSpec defines the desired state of SPIAccessTokenDataUpdate
+          properties:
+            tokenName:
+              description: TokenName is the name of the SPIAccessToken object in the
+                same namespace as the update object
+              type: string
+          required:
+          - tokenName
+          type: object
+      required:
+      - spec
+      type: object
+    served: true
+    storage: true
+    subresources: {}
+
+---
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: 2022-06-09-17-22.spiaccesstokens.appstudio.redhat.com
+spec:
+  group: appstudio.redhat.com
+  names:
+    kind: SPIAccessToken
+    listKind: SPIAccessTokenList
+    plural: spiaccesstokens
+    singular: spiaccesstoken
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      description: SPIAccessToken is the Schema for the spiaccesstokens API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SPIAccessTokenSpec defines the desired state of SPIAccessToken
+          properties:
+            permissions:
+              description: Permissions is a collection of operator-defined permissions
+                (which are translated to service-provider-specific scopes) and potentially
+                additional service-provider-specific scopes that are not covered by
+                the operator defined abstraction. The permissions are used in SPIAccessTokenBinding
+                objects to express the requirements on the tokens as well as in the
+                SPIAccessToken objects to express the "capabilities" of the token.
+              properties:
+                additionalScopes:
+                  items:
+                    type: string
+                  type: array
+                required:
+                  items:
+                    description: Permission is an element of Permissions and express
+                      a requirement on the service provider scopes in an agnostic
+                      manner.
+                    properties:
+                      area:
+                        description: Area express the "area" in the service provider
+                          scopes to which the permission is required.
+                        type: string
+                      type:
+                        description: Type is the type of the permission required
+                        type: string
+                    required:
+                    - area
+                    - type
+                    type: object
+                  type: array
+              type: object
+            serviceProviderUrl:
+              type: string
+          required:
+          - permissions
+          - serviceProviderUrl
+          type: object
+        status:
+          description: SPIAccessTokenStatus defines the observed state of SPIAccessToken
+          properties:
+            errorMessage:
+              type: string
+            errorReason:
+              description: SPIAccessTokenErrorReason is the enumeration of reasons
+                for the token being invalid
+              type: string
+            oAuthUrl:
+              type: string
+            phase:
+              description: SPIAccessTokenPhase is the reconciliation phase of the
+                SPIAccessToken object
+              type: string
+            tokenMetadata:
+              description: TokenMetadata is data about the token retrieved from the
+                service provider. This data can be used for matching the tokens with
+                the token bindings.
+              properties:
+                lastRefreshTime:
+                  description: LastRefreshTime is the Unix-epoch timestamp of the
+                    last time the metadata has been refreshed from the service provider.
+                    The operator is configured with a TTL for this information and
+                    automatically refreshes the metadata when it is needed but is
+                    found stale.
+                  format: int64
+                  type: integer
+                scopes:
+                  description: Scopes is the list of OAuth scopes that this token
+                    possesses
+                  items:
+                    type: string
+                  type: array
+                serviceProviderState:
+                  description: ServiceProviderState is an opaque state specific to
+                    the service provider. This includes data that the operator uses
+                    during token matching, etc.
+                  format: byte
+                  type: string
+                userId:
+                  description: UserId is the user id in the service provider that
+                    this token impersonates as
+                  type: string
+                username:
+                  description: Username is the username in the service provider that
+                    this token impersonates as
+                  type: string
+              required:
+              - lastRefreshTime
+              type: object
+          required:
+          - errorMessage
+          - errorReason
+          - oAuthUrl
+          - phase
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---

--- a/config/kcp/apiresourceschema_spi.yaml
+++ b/config/kcp/apiresourceschema_spi.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091739.spiaccesschecks.appstudio.redhat.com
+  name: v202206091758.spiaccesschecks.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -104,7 +104,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091739.spiaccesstokenbindings.appstudio.redhat.com
+  name: v202206091758.spiaccesstokenbindings.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -295,7 +295,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091739.spiaccesstokendataupdates.appstudio.redhat.com
+  name: v202206091758.spiaccesstokendataupdates.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -350,7 +350,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091739.spiaccesstokens.appstudio.redhat.com
+  name: v202206091758.spiaccesstokens.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:

--- a/config/kcp/apiresourceschema_spi.yaml
+++ b/config/kcp/apiresourceschema_spi.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 2022-06-09-15-50.spiaccesschecks.appstudio.redhat.com
+  name: 202206091552.spiaccesschecks.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -104,7 +104,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 2022-06-09-15-50.spiaccesstokenbindings.appstudio.redhat.com
+  name: 202206091552.spiaccesstokenbindings.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -295,7 +295,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 2022-06-09-15-50.spiaccesstokendataupdates.appstudio.redhat.com
+  name: 202206091552.spiaccesstokendataupdates.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -350,7 +350,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 2022-06-09-15-50.spiaccesstokens.appstudio.redhat.com
+  name: 202206091552.spiaccesstokens.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:

--- a/config/kcp/apiresourceschema_spi.yaml
+++ b/config/kcp/apiresourceschema_spi.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091758.spiaccesschecks.appstudio.redhat.com
+  name: v202206100727.spiaccesschecks.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -104,7 +104,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091758.spiaccesstokenbindings.appstudio.redhat.com
+  name: v202206100727.spiaccesstokenbindings.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -295,7 +295,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091758.spiaccesstokendataupdates.appstudio.redhat.com
+  name: v202206100727.spiaccesstokendataupdates.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -350,7 +350,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v202206091758.spiaccesstokens.appstudio.redhat.com
+  name: v202206100727.spiaccesstokens.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:

--- a/config/kcp/apiresourceschema_spi.yaml
+++ b/config/kcp/apiresourceschema_spi.yaml
@@ -5,7 +5,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 2022-06-09-17-22.spiaccesschecks.appstudio.redhat.com
+  name: 2022-06-09-15-50.spiaccesschecks.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -104,7 +104,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 2022-06-09-17-22.spiaccesstokenbindings.appstudio.redhat.com
+  name: 2022-06-09-15-50.spiaccesstokenbindings.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -295,7 +295,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 2022-06-09-17-22.spiaccesstokendataupdates.appstudio.redhat.com
+  name: 2022-06-09-15-50.spiaccesstokendataupdates.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:
@@ -350,7 +350,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: 2022-06-09-17-22.spiaccesstokens.appstudio.redhat.com
+  name: 2022-06-09-15-50.spiaccesstokens.appstudio.redhat.com
 spec:
   group: appstudio.redhat.com
   names:

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - apiexport_spi.yaml
+  - apiresourceschema_spi.yaml

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -29,7 +29,7 @@ EOF
 # APIResourceSchema is immutable so when we want to update something, we actually have to create new version.
 # Version is defined by this prefix, which is taken from date. This will allow us to do new version each minute, which
 # should be hopefully enough granularity :)
-PREFIX=$( date +%Y-%m-%d-%H-%M )
+PREFIX=$( TZ="Etc/UTC" date +%Y-%m-%d-%H-%M )
 
 I=0
 for CRD in $( ls ${CRD_DIR} ); do

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -59,7 +59,7 @@ metadata:
 spec:
   latestResourceSchemas:
 EOF
-set -x
+
 I=0
 for SCHEMA in $( yq -y '.metadata.name' ${KCP_API_SCHEMA_FILE_CURRENT} | yq -r 'select (.!=null)' ); do
   QUERY=".spec.latestResourceSchemas[${I}]=env.SCHEMA"

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -33,14 +33,14 @@ PREFIX=$( TZ="Etc/UTC" date +%Y%m%d%H%M )
 
 I=0
 for CRD in $( ls ${CRD_DIR} ); do
-  kubectl-kcp crd snapshot -f "${CRD_DIR}/${CRD}" --prefix ${PREFIX} >> ${KCP_API_SCHEMA_FILE_NEW}
+  kubectl-kcp crd snapshot -f "${CRD_DIR}/${CRD}" --prefix v${PREFIX} >> ${KCP_API_SCHEMA_FILE_NEW}
 done
 
 # If there are some changes in new generated file, we replace old one. Otherwise just remove new file.
 # The regex is there to ignore name change, because we're updating date there so it is expected to change.
 # Ignored line looks like this:
 # '  name: 202206091540.spiaccesstokendataupdates.appstudio.redhat.com'
-if ! diff -I '^  name: [0-9]\{12\}\..*\.appstudio\.redhat\.com$' ${KCP_API_SCHEMA_FILE_CURRENT} ${KCP_API_SCHEMA_FILE_NEW} > /dev/null; then
+if ! diff -I '^  name: v[0-9]\{12\}\..*\.appstudio\.redhat\.com$' ${KCP_API_SCHEMA_FILE_CURRENT} ${KCP_API_SCHEMA_FILE_NEW} > /dev/null; then
   mv ${KCP_API_SCHEMA_FILE_NEW} ${KCP_API_SCHEMA_FILE_CURRENT}
   echo "updated KCP APIResourceSchema for SPI saved at '${KCP_API_SCHEMA_FILE_CURRENT}'"
 else

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -39,7 +39,7 @@ done
 # If there are some changes in new generated file, we replace old one. Otherwise just remove new file.
 # The regex is there to ignore name change, because we're updating date there so it is expected to change.
 # Ignored line looks like this:
-# '  name: 202206091540.spiaccesstokendataupdates.appstudio.redhat.com'
+# '  name: v202206091540.spiaccesstokendataupdates.appstudio.redhat.com'
 if ! diff -I '^  name: v[0-9]\{12\}\..*\.appstudio\.redhat\.com$' ${KCP_API_SCHEMA_FILE_CURRENT} ${KCP_API_SCHEMA_FILE_NEW} > /dev/null; then
   mv ${KCP_API_SCHEMA_FILE_NEW} ${KCP_API_SCHEMA_FILE_CURRENT}
   echo "updated KCP APIResourceSchema for SPI saved at '${KCP_API_SCHEMA_FILE_CURRENT}'"
@@ -52,9 +52,6 @@ fi
 # now create APIExport and link all created APIResourceSchemas there
 KCP_API_EXPORT_FILE="${KCP_API_DIR}/apiexport_spi.yaml"
 cat << EOF > ${KCP_API_EXPORT_FILE}
-# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
-# Please do not modify!
-
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
@@ -64,13 +61,18 @@ spec:
 EOF
 
 I=0
-for SCHEMA in $( yq '.metadata.name' ${KCP_API_SCHEMA_FILE_CURRENT} ); do
-  # because we have multiple yamls in single file, yq gives us --- separators in the output.
-  # Also last line is null, because kubectl-kcp generates end of file with ---
-  if [ "$SCHEMA" = "---" ] || [ "$SCHEMA" = "null" ]; then
+for SCHEMA in $( yq -r '.metadata.name' ${KCP_API_SCHEMA_FILE_CURRENT} ); do
+  if [ "${SCHEMA}" == "null" ]; then
     continue
   fi
-
-  I=${I} SCHEMA=${SCHEMA} yq -i '.spec.latestResourceSchemas[env(I)] = env(SCHEMA)' ${KCP_API_EXPORT_FILE}
+  QUERY=".spec.latestResourceSchemas[${I}]=env.SCHEMA"
+  SCHEMA=${SCHEMA} yq -i -y ${QUERY} ${KCP_API_EXPORT_FILE}
   I=$((I + 1))
 done
+
+cat << EOF > ${KCP_API_EXPORT_FILE}
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+
+$( cat ${KCP_API_EXPORT_FILE} )
+EOF

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -59,12 +59,9 @@ metadata:
 spec:
   latestResourceSchemas:
 EOF
-
+set -x
 I=0
-for SCHEMA in $( yq -r '.metadata.name' ${KCP_API_SCHEMA_FILE_CURRENT} ); do
-  if [ "${SCHEMA}" == "null" ]; then
-    continue
-  fi
+for SCHEMA in $( yq -y '.metadata.name' ${KCP_API_SCHEMA_FILE_CURRENT} | yq -r 'select (.!=null)' ); do
   QUERY=".spec.latestResourceSchemas[${I}]=env.SCHEMA"
   SCHEMA=${SCHEMA} yq -i -y ${QUERY} ${KCP_API_EXPORT_FILE}
   I=$((I + 1))

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -29,7 +29,7 @@ EOF
 # APIResourceSchema is immutable so when we want to update something, we actually have to create new version.
 # Version is defined by this prefix, which is taken from date. This will allow us to do new version each minute, which
 # should be hopefully enough granularity :)
-PREFIX=$( TZ="Etc/UTC" date +%Y-%m-%d-%H-%M )
+PREFIX=$( TZ="Etc/UTC" date +%Y%m%d%H%M )
 
 I=0
 for CRD in $( ls ${CRD_DIR} ); do
@@ -39,8 +39,8 @@ done
 # If there are some changes in new generated file, we replace old one. Otherwise just remove new file.
 # The regex is there to ignore name change, because we're updating date there so it is expected to change.
 # Ignored line looks like this:
-# '  name: 2022-06-09-15-40.spiaccesstokendataupdates.appstudio.redhat.com'
-if ! diff -I '^  name: [0-9]\{4\}\(-[0-9][0-9]\)\{4\}\..*\.appstudio\.redhat\.com$' ${KCP_API_SCHEMA_FILE_CURRENT} ${KCP_API_SCHEMA_FILE_NEW} > /dev/null; then
+# '  name: 202206091540.spiaccesstokendataupdates.appstudio.redhat.com'
+if ! diff -I '^  name: [0-9]\{12\}\..*\.appstudio\.redhat\.com$' ${KCP_API_SCHEMA_FILE_CURRENT} ${KCP_API_SCHEMA_FILE_NEW} > /dev/null; then
   mv ${KCP_API_SCHEMA_FILE_NEW} ${KCP_API_SCHEMA_FILE_CURRENT}
   echo "updated KCP APIResourceSchema for SPI saved at '${KCP_API_SCHEMA_FILE_CURRENT}'"
 else

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if ! which yq; then
-  echo "yq required"
-  exit 1
-fi
-
 if ! which kubectl-kcp; then
   echo "kubectl-kcp required on path"
   echo "you can install it with running:"
@@ -60,11 +55,9 @@ spec:
   latestResourceSchemas:
 EOF
 
-I=0
-for SCHEMA in $( yq -y '.metadata.name' ${KCP_API_SCHEMA_FILE_CURRENT} | yq -r 'select (.!=null)' ); do
-  QUERY=".spec.latestResourceSchemas[${I}]=env.SCHEMA"
-  SCHEMA=${SCHEMA} yq -i -y ${QUERY} ${KCP_API_EXPORT_FILE}
-  I=$((I + 1))
+# match APIResourceSchema name pattern with date prefix
+for SCHEMA in $( cat ${KCP_API_SCHEMA_FILE_CURRENT} | grep -o "v[0-9]\{12\}\..*\.appstudio\.redhat\.com" ); do
+  echo "    - ${SCHEMA}" >> ${KCP_API_EXPORT_FILE}
 done
 
 cat << EOF > ${KCP_API_EXPORT_FILE}

--- a/hack/generate-kcp-api.sh
+++ b/hack/generate-kcp-api.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+set -e
+
+if ! which yq; then
+  echo "yq required"
+  exit 1
+fi
+
+if ! which kubectl-kcp; then
+  echo "kubectl-kcp required on path"
+  echo "you can install it with running:"
+  echo "    $ git clone https://github.com/kcp-dev/kcp && cd kcp && make install"
+  exit 1
+fi
+
+THIS_DIR="$(dirname "$(realpath "$0")")"
+CRD_DIR="$( realpath ${THIS_DIR}/../config/crd/bases)"
+KCP_API_DIR="$( realpath ${THIS_DIR}/../config/kcp)"
+
+KCP_API_SCHEMA_FILE_CURRENT="${KCP_API_DIR}/apiresourceschema_spi.yaml"
+KCP_API_SCHEMA_FILE_NEW="${KCP_API_DIR}/apiresourceschema_spi.yaml_new"
+cat << EOF > ${KCP_API_SCHEMA_FILE_NEW}
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+
+EOF
+
+# APIResourceSchema is immutable so when we want to update something, we actually have to create new version.
+# Version is defined by this prefix, which is taken from date. This will allow us to do new version each minute, which
+# should be hopefully enough granularity :)
+PREFIX=$( date +%Y-%m-%d-%H-%M )
+
+I=0
+for CRD in $( ls ${CRD_DIR} ); do
+  kubectl-kcp crd snapshot -f "${CRD_DIR}/${CRD}" --prefix ${PREFIX} >> ${KCP_API_SCHEMA_FILE_NEW}
+done
+
+# If there are some changes in new generated file, we replace old one. Otherwise just remove new file.
+# The regex is there to ignore name change, because we're updating date there so it is expected to change.
+# Ignored line looks like this:
+# '  name: 2022-06-09-15-40.spiaccesstokendataupdates.appstudio.redhat.com'
+if ! diff -I '^  name: [0-9]\{4\}\(-[0-9][0-9]\)\{4\}\..*\.appstudio\.redhat\.com$' ${KCP_API_SCHEMA_FILE_CURRENT} ${KCP_API_SCHEMA_FILE_NEW} > /dev/null; then
+  mv ${KCP_API_SCHEMA_FILE_NEW} ${KCP_API_SCHEMA_FILE_CURRENT}
+  echo "updated KCP APIResourceSchema for SPI saved at '${KCP_API_SCHEMA_FILE_CURRENT}'"
+else
+  echo "no changes in KCP API"
+  rm ${KCP_API_SCHEMA_FILE_NEW}
+fi
+
+
+# now create APIExport and link all created APIResourceSchemas there
+KCP_API_EXPORT_FILE="${KCP_API_DIR}/apiexport_spi.yaml"
+cat << EOF > ${KCP_API_EXPORT_FILE}
+# This file is generated from CRDs by ./hack/generate-kcp-api.sh script.
+# Please do not modify!
+
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: spi
+spec:
+  latestResourceSchemas:
+EOF
+
+I=0
+for SCHEMA in $( yq '.metadata.name' ${KCP_API_SCHEMA_FILE_CURRENT} ); do
+  # because we have multiple yamls in single file, yq gives us --- separators in the output.
+  # Also last line is null, because kubectl-kcp generates end of file with ---
+  if [ "$SCHEMA" = "---" ] || [ "$SCHEMA" = "null" ]; then
+    continue
+  fi
+
+  I=${I} SCHEMA=${SCHEMA} yq -i '.spec.latestResourceSchemas[env(I)] = env(SCHEMA)' ${KCP_API_EXPORT_FILE}
+  I=$((I + 1))
+done


### PR DESCRIPTION
### What does this PR do?
 - add `APIResourceSchema` for all our CRDs
 - add `APIExport` linking all `APIResourceSchema`s
 - add script to generate new version of `APIResourceSchema` on CRD change
 - make script runnable by `make manifests-kcp`, also added as dependency of `make manifests`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-91

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
script requires `kubectl-kcp` to run properly. I've tried to write simple instructions how to install it.

 - run `make manifests-kcp`, you should see something like `no changes in KCP API`
 - do some change in one of CRDs, change some field name for example
 - run `make manifests-kcp` again. you should see updated `apiresourceschema_spi.yaml` file with your changes and current datetime as a name prefix. `apiexport_spi.yaml` must contain updated schemas with latest datetime.