### PR TITLE
Logger sugaring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/go-jose/go-jose/v3 v3.0.0
+	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/google/go-cmp v0.5.7
@@ -70,7 +71,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/go-test/deep v1.0.8 // indirect

--- a/main.go
+++ b/main.go
@@ -21,9 +21,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/go-logr/zapr"
-	"go.uber.org/zap"
-
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceproviders"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
@@ -38,15 +36,13 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	appstudiov1beta1 "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	appstudiov1beta1 "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 
 	//+kubebuilder:scaffold:imports
 
@@ -80,15 +76,7 @@ func main() {
 
 	flag.Parse()
 
-	opts := crzap.Options{}
-	opts.BindFlags(flag.CommandLine)
-	opts.Development = devmode
-
-	// set everything up such that we can use the same logger in controller runtime zap.L().*
-	logger := crzap.NewRaw(crzap.UseFlagOptions(&opts))
-	_ = zap.ReplaceGlobals(logger)
-	ctrl.SetLogger(zapr.NewLogger(logger))
-
+	logs.InitLoggers(devmode, flag.CommandLine)
 	setupLog := ctrl.Log.WithName("setup")
 
 	if err := config.ValidateEnv(); err != nil {

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"flag"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	DebugLvl = 1
+)
+
+// InitLoggers Configure zap backend for controller-runtime logger.
+func InitLoggers(development bool, fs *flag.FlagSet) {
+
+	opts := crzap.Options{ZapOpts: []zap.Option{zap.WithCaller(true), zap.AddCallerSkip(-2)}}
+	opts.BindFlags(fs)
+	opts.Development = development
+
+	// set everything up such that we can use the same logger in controller runtime zap.L().*
+	logger := crzap.NewRaw(crzap.UseFlagOptions(&opts))
+	_ = zap.ReplaceGlobals(logger)
+	ctrl.SetLogger(zapr.NewLogger(logger))
+}
+
+// TimeTrack used to time any function
+// Example:
+//  {
+//    defer logs.TimeTrack(lg, time.Now(), "fetch all github repositories")
+//  }
+func TimeTrack(log logr.Logger, start time.Time, name string) {
+	elapsed := time.Since(start)
+	log.V(DebugLvl).Info("Time took", "name", name, "time", elapsed)
+}

--- a/pkg/serviceprovider/github/github_test.go
+++ b/pkg/serviceprovider/github/github_test.go
@@ -16,11 +16,14 @@ package github
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,6 +70,10 @@ func (t tokenStorageMock) Delete(ctx context.Context, owner *api.SPIAccessToken)
 	return nil
 }
 
+func TestMain(m *testing.M) {
+	logs.InitLoggers(true, flag.CommandLine)
+	os.Exit(m.Run())
+}
 func TestCheckPublicRepo(t *testing.T) {
 	test := func(statusCode int, expected bool) {
 		t.Run(fmt.Sprintf("code %d => %t", statusCode, expected), func(t *testing.T) {

--- a/pkg/serviceprovider/lookup_test.go
+++ b/pkg/serviceprovider/lookup_test.go
@@ -16,10 +16,13 @@ package serviceprovider
 
 import (
 	"context"
+	"flag"
+	"os"
 	"testing"
 	"time"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +31,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestMain(m *testing.M) {
+	logs.InitLoggers(true, flag.CommandLine)
+	os.Exit(m.Run())
+}
 
 func TestGenericLookup_Lookup(t *testing.T) {
 	matchingToken := &api.SPIAccessToken{

--- a/pkg/serviceprovider/quay/quay_test.go
+++ b/pkg/serviceprovider/quay/quay_test.go
@@ -17,10 +17,13 @@ package quay
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
@@ -36,6 +39,11 @@ import (
 )
 
 const testValidRepoUrl = "https://quay.io/repository/redhat-appstudio/service-provider-integration-operator"
+
+func TestMain(m *testing.M) {
+	logs.InitLoggers(true, flag.CommandLine)
+	os.Exit(m.Run())
+}
 
 func TestQuayProbe_Examine(t *testing.T) {
 	probe := quayProbe{}


### PR DESCRIPTION
### What does this PR do?
Added a bit of logger sugar.
 - A separate method to initialize operator logger, global logger that can be reused from code
 - Setup logger in individual packages with Test_Main method
 - TimeTrack - method to measure method execution time.
 

Context https://github.com/redhat-appstudio/service-provider-integration-operator/pull/147#pullrequestreview-1004160666

### Screenshot/screencast of this PR
Before 
<img width="1396" alt="Знімок екрана 2022-06-13 о 15 15 52" src="https://user-images.githubusercontent.com/1614429/173352252-91476739-9d64-452e-ae2a-4ae0b62c95c5.png">


After

<img width="1462" alt="Знімок екрана 2022-06-13 о 15 14 35" src="https://user-images.githubusercontent.com/1614429/173352281-b544d9cb-7f76-4de0-94b2-e6eeb0cc0f24.png">

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-140


### How to test this PR?
Build and run test in some of the packages. `make test` for some reason has no affect.
