### PR TITLE
Align route name with infra-deployment and service-provider-integraion-scm-file-retriever

### DIFF
--- a/config/openshift-example/route.yaml
+++ b/config/openshift-example/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: route
+  name: oauth-route
 spec:
   port:
     targetPort: 8000


### PR DESCRIPTION
### What does this PR do?
Align route name with infra-deployment and service-provider-integraion-scm-file-retriever
 - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/blob/61a964c0bc04ab536cd2d0281886cda2fad82704/server/config/os/oauth_route.yaml#L4
 - https://github.com/redhat-appstudio/infra-deployments/blob/7142c6a3638c4a715ed3a99f38cf92c3c7ed6f1d/components/spi/oauth_route.yaml#L4

SPI prefix would be added by `kustomize`.

### Screenshot/screencast of this PR
![Знімок екрана 2022-06-17 о 16 35 50](https://user-images.githubusercontent.com/1614429/174309519-a8b65144-4258-46dc-a901-c3988eaa1a93.png)
<img width="1725" alt="Знімок екрана 2022-06-17 о 16 49 14" src="https://user-images.githubusercontent.com/1614429/174311348-ebaf48d5-47f0-4192-982f-b918825426d2.png">


### What issues does this PR fix or reference?
- Simplify wring scripts that is reusable during local development on minikube/openshift and staging/production.


### How to test this PR?
- check pr's branch
- make deploy_openshift/deploy_minikube
- `oc get route/spi-oauth-route --namespace=spi-system -o=jsonpath={'.spec.host'}`