### PR TITLE
require maximum reasonable set of scopes from Quay

### DIFF
--- a/controllers/spiaccesstoken_controller.go
+++ b/controllers/spiaccesstoken_controller.go
@@ -282,7 +282,7 @@ func (r *SPIAccessTokenReconciler) oAuthUrlFor(ctx context.Context, at *api.SPIA
 		TokenName:           at.Name,
 		TokenNamespace:      at.Namespace,
 		IssuedAt:            time.Now().Unix(),
-		Scopes:              serviceprovider.GetAllScopes(sp.TranslateToScopes, &at.Spec.Permissions),
+		Scopes:              sp.OAuthScopesFor(&at.Spec.Permissions),
 		ServiceProviderType: config.ServiceProviderType(sp.GetType()),
 		ServiceProviderUrl:  sp.GetBaseUrl(),
 	})

--- a/integration_tests/serviceprovider_mock.go
+++ b/integration_tests/serviceprovider_mock.go
@@ -30,7 +30,7 @@ type TestServiceProvider struct {
 	LookupTokenImpl           func(context.Context, client.Client, *api.SPIAccessTokenBinding) (*api.SPIAccessToken, error)
 	PersistMetadataImpl       func(context.Context, client.Client, *api.SPIAccessToken) error
 	GetBaseUrlImpl            func() string
-	TranslateToScopesImpl     func(permission api.Permission) []string
+	OAuthScopesForImpl        func(permissions *api.Permissions) []string
 	GetTypeImpl               func() api.ServiceProviderType
 	GetOauthEndpointImpl      func() string
 	CheckRepositoryAccessImpl func(context.Context, client.Client, *api.SPIAccessCheck) (*api.SPIAccessCheckStatus, error)
@@ -67,11 +67,11 @@ func (t TestServiceProvider) GetBaseUrl() string {
 	return t.GetBaseUrlImpl()
 }
 
-func (t TestServiceProvider) TranslateToScopes(permission api.Permission) []string {
-	if t.TranslateToScopesImpl == nil {
+func (t TestServiceProvider) OAuthScopesFor(permissions *api.Permissions) []string {
+	if t.OAuthScopesForImpl == nil {
 		return []string{}
 	}
-	return t.TranslateToScopesImpl(permission)
+	return t.OAuthScopesForImpl(permissions)
 }
 
 func (t TestServiceProvider) GetType() api.ServiceProviderType {
@@ -107,7 +107,7 @@ func (t TestServiceProvider) Validate(ctx context.Context, validated serviceprov
 func (t *TestServiceProvider) Reset() {
 	t.LookupTokenImpl = nil
 	t.GetBaseUrlImpl = nil
-	t.TranslateToScopesImpl = nil
+	t.OAuthScopesForImpl = nil
 	t.GetTypeImpl = nil
 	t.GetOauthEndpointImpl = nil
 	t.PersistMetadataImpl = nil

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -268,7 +268,9 @@ var _ = AfterSuite(func() {
 	}
 
 	By("tearing down the test environment")
-	ITest.VaultTestCluster.Cleanup()
+	if ITest.VaultTestCluster != nil {
+		ITest.VaultTestCluster.Cleanup()
+	}
 	if ITest.TestEnvironment != nil {
 		err := ITest.TestEnvironment.Stop()
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/serviceprovider/github/github.go
+++ b/pkg/serviceprovider/github/github.go
@@ -98,8 +98,8 @@ func (g *Github) GetType() api.ServiceProviderType {
 	return api.ServiceProviderTypeGitHub
 }
 
-func (g *Github) TranslateToScopes(permission api.Permission) []string {
-	return translateToScopes(permission)
+func (g *Github) OAuthScopesFor(permissions *api.Permissions) []string {
+	return serviceprovider.GetAllScopes(translateToScopes, permissions)
 }
 
 func translateToScopes(permission api.Permission) []string {

--- a/pkg/serviceprovider/hostcredentials/hostcredentials.go
+++ b/pkg/serviceprovider/hostcredentials/hostcredentials.go
@@ -80,7 +80,7 @@ func (g *HostCredentialsProvider) GetType() api.ServiceProviderType {
 	return api.ServiceProviderTypeHostCredentials
 }
 
-func (g *HostCredentialsProvider) TranslateToScopes(_ api.Permission) []string {
+func (g *HostCredentialsProvider) OAuthScopesFor(_ *api.Permissions) []string {
 	return []string{}
 }
 

--- a/pkg/serviceprovider/quay/quay_test.go
+++ b/pkg/serviceprovider/quay/quay_test.go
@@ -181,40 +181,65 @@ func TestValidate(t *testing.T) {
 	assert.Equal(t, "unsupported scope 'user:read'", res.ScopeValidation[2].Error())
 }
 
-func TestQuay_TranslateToScopes(t *testing.T) {
-	repoR := api.Permission{
-		Area: api.PermissionAreaRepository,
-		Type: api.PermissionTypeRead,
-	}
-	repoW := api.Permission{
-		Area: api.PermissionAreaRepository,
-		Type: api.PermissionTypeWrite,
-	}
-	repoRW := api.Permission{
-		Area: api.PermissionAreaRepository,
-		Type: api.PermissionTypeReadWrite,
-	}
-	repoMR := api.Permission{
-		Area: api.PermissionAreaRepositoryMetadata,
-		Type: api.PermissionTypeRead,
-	}
-	repoMW := api.Permission{
-		Area: api.PermissionAreaRepositoryMetadata,
-		Type: api.PermissionTypeWrite,
-	}
-	repoMRW := api.Permission{
-		Area: api.PermissionAreaRepositoryMetadata,
-		Type: api.PermissionTypeReadWrite,
-	}
+func TestQuay_OAuthScopesFor(t *testing.T) {
 
 	q := &Quay{}
+	fullScopes := []string{"repo:read", "repo:write", "repo:create", "repo:admin"}
 
-	assert.Equal(t, []string{"repo:read"}, q.TranslateToScopes(repoR))
-	assert.Equal(t, []string{"repo:write"}, q.TranslateToScopes(repoW))
-	assert.Equal(t, []string{"repo:read", "repo:write"}, q.TranslateToScopes(repoRW))
-	assert.Equal(t, []string{"repo:read"}, q.TranslateToScopes(repoMR))
-	assert.Equal(t, []string{"repo:write"}, q.TranslateToScopes(repoMW))
-	assert.Equal(t, []string{"repo:read", "repo:write"}, q.TranslateToScopes(repoMRW))
+	hasScopes := func(expectedScopes []string, ps api.Permissions) func(t *testing.T) {
+		return func(t *testing.T) {
+			actualScopes := q.OAuthScopesFor(&ps)
+			assert.Equal(t, len(expectedScopes), len(actualScopes))
+			for _, s := range expectedScopes {
+				assert.Contains(t, actualScopes, s)
+			}
+		}
+	}
+
+	hasDefault := func(ps api.Permissions) func(t *testing.T) {
+		return hasScopes(fullScopes, ps)
+	}
+
+	t.Run("empty", hasDefault(api.Permissions{}))
+	t.Run("read-repo", hasDefault(api.Permissions{Required: []api.Permission{
+		{
+			Area: api.PermissionAreaRepository,
+			Type: api.PermissionTypeRead,
+		},
+	}}))
+	t.Run("write-repo", hasDefault(api.Permissions{Required: []api.Permission{
+		{
+			Area: api.PermissionAreaRepository,
+			Type: api.PermissionTypeWrite,
+		},
+	}}))
+	t.Run("read-write-repo", hasDefault(api.Permissions{Required: []api.Permission{
+		{
+			Area: api.PermissionAreaRepository,
+			Type: api.PermissionTypeReadWrite,
+		},
+	}}))
+	t.Run("read-meta", hasDefault(api.Permissions{Required: []api.Permission{
+		{
+			Area: api.PermissionAreaRepositoryMetadata,
+			Type: api.PermissionTypeRead,
+		},
+	}}))
+	t.Run("write-meta", hasDefault(api.Permissions{Required: []api.Permission{
+		{
+			Area: api.PermissionAreaRepositoryMetadata,
+			Type: api.PermissionTypeWrite,
+		},
+	}}))
+	t.Run("read-write-meta", hasDefault(api.Permissions{Required: []api.Permission{
+		{
+			Area: api.PermissionAreaRepositoryMetadata,
+			Type: api.PermissionTypeReadWrite,
+		},
+	}}))
+	t.Run("additional-scopes", hasScopes(
+		[]string{"repo:read", "repo:write", "repo:create", "repo:admin", "org:admin"},
+		api.Permissions{AdditionalScopes: []string{"org:admin"}}))
 }
 
 func TestRequestRepoInfo(t *testing.T) {

--- a/pkg/serviceprovider/serviceprovider.go
+++ b/pkg/serviceprovider/serviceprovider.go
@@ -48,8 +48,10 @@ type ServiceProvider interface {
 	// SPIAccessTokens so that later on, the OAuth service can use it to construct the OAuth flow URLs.
 	GetBaseUrl() string
 
-	// TranslateToScopes translates the provided permission object into (a set of) service-provider-specific scopes.
-	TranslateToScopes(permission api.Permission) []string
+	// OAuthScopesFor translates all the permissions into a list of service-provider-specific scopes. This method
+	// is used to compose the OAuth flow URL. There is a generic helper, GetAllScopes, that can be used if all that is
+	// needed is just a translation of permissions into scopes.
+	OAuthScopesFor(permissions *api.Permissions) []string
 
 	// GetType merely returns the type of the service provider this instance talks to.
 	GetType() api.ServiceProviderType


### PR DESCRIPTION
### What does this PR do?
Require maximum reasonable set of scopes from Quay regardless of the required permissions to work around https://issues.redhat.com/browse/PROJQUAY-3908.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-144

### How to test this PR?
1. `cd <SPI_OPERATOR>`
1. `make install deploy_minikube SPIO_IMG=quay.io/lkrejci/service-provider-integration-operator:svpi-144`
2. run `hack/edit-spi-config.sh`, set the shared secret and provide your Quay OAuth app `clientID` and `clientSecret`.
3. `kubectl apply -f hack/give-default-sa-perms-for-accesstokens.yaml`
4. `kubectl apply -f samples/binding-read-repo-quay.yaml`
5. `cd <OAUTH_SERVICE>`
6. `firefox hack/oauth-ui.html`
7. copy the OAuth URL from `kubectl get spiaccesstokenbinding binding-read-repository -ojsonpath='{.status.oAuthUrl}'` to the OAuth Url field in the UI.
8. copy the token from `./hack/get-default-sa-token.sh` to the "K8s token" field in the UI.
9. Click "Login" button, then go back in history and click "Initiate OAuth"
10. Go through the OAuth flow in Quay and make sure that Quay asks if it is OK to give "Create repositories", "Administer Repositories", "Read/Write to any accessible repositories" and "View all visible repositories" permissions.
11. Once granted, the binding created in the step 5, should flip to the "Injected" state.