### PR TITLE
get token of default SA in default namespace in kubernetes 1.24+

### DIFF
--- a/hack/get-default-sa-token.sh
+++ b/hack/get-default-sa-token.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-kubectl create token default -n default
+KUBE_VERSION=$( kubectl version -o json | jq -r .serverVersion.minor )
+
+# Kubernetes 24+ doesn't create secret with token for serviceaccount
+if [ "${KUBE_VERSION}" -ge "24" ]; then
+  kubectl create token default -n default
+else
+  SECRET_NAME=$(kubectl get serviceaccount default -n default -o jsonpath='{.secrets[0].name}')
+  kubectl get secret "${SECRET_NAME}" -o jsonpath='{.data.token}' | base64 -d
+fi

--- a/hack/get-default-sa-token.sh
+++ b/hack/get-default-sa-token.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-SECRET_NAME=$(kubectl get serviceaccount default -n default -o jsonpath='{.secrets[0].name}')
-
-kubectl get secret "${SECRET_NAME}" -o jsonpath='{.data.token}' | base64 -d
+kubectl create token default -n default


### PR DESCRIPTION
### What does this PR do?
In kubernetes 1.24, secret with SA tokens are not automatically generated anymore https://github.com/kubernetes/kubernetes/pull/108309

This PR updates our hack script to get the default token, that was taken from this secret before.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
