### PR TITLE
Defaults and environment variables as tags on config struct

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	strg, err := tokenstorage.NewVaultStorage("spi-controller-manager", cfg.VaultHost, cfg.ServiceAccountTokenFilePath, devmode)
+	strg, err := tokenstorage.NewVaultStorage("spi-controller-manager", cfg.VaultConfiguration.Host, cfg.VaultConfiguration.KubernetesAuthentication.ServiceAccountTokenFilePath, devmode)
 	if err != nil {
 		setupLog.Error(err, "failed to initialize the token storage")
 		os.Exit(1)


### PR DESCRIPTION
### What does this PR do?
Declare the default values and names of env vars that can override the configured values as tags on the PersistedConfiguration struct fields.

Slightly reshaped the Vault configuration in preparation for the future enhancements.

### What issues does this PR fix or reference?
NA

### How to test this PR?
It should be possible to declare the newly defined environment variables on the operator pod to override the configuration options specified within the configuration file.
