### PR TITLE
Increase memory limits for OAuth service

### DIFF
--- a/config/oauth/deployment.yaml
+++ b/config/oauth/deployment.yaml
@@ -39,10 +39,10 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 100Mi
+              memory: 200Mi
             requests:
               cpu: 100m
-              memory: 20Mi
+              memory: 100Mi
           volumeMounts:
           - mountPath: /etc/spi/
             name: oauth-config


### PR DESCRIPTION
### What does this PR do?
Increase memory limits for OAuth service

### Screenshot/screencast of this PR
Before
<img width="1723" alt="Знімок екрана 2022-07-14 о 13 20 03" src="https://user-images.githubusercontent.com/1614429/178960849-a6df6c2f-3c99-43be-a144-0cfba206c9c1.png">
After

<img width="1722" alt="Знімок екрана 2022-07-14 о 13 23 32" src="https://user-images.githubusercontent.com/1614429/178961453-03ae0d42-7c36-490f-9594-96b9fd9b167c.png">

### What issues does this PR fix or reference?
OAuth services after the start uses 84M with a limit 100m

### How to test this PR?
- `make deploy` from pr branch 
- Test token upload of OAuth flow.
