### PR TITLE
vault audit log to stdout

### DIFF
--- a/hack/vault-init.sh
+++ b/hack/vault-init.sh
@@ -117,7 +117,7 @@ function generateRootToken() {
 function audit() {
   if ! vaultExec "vault audit list | grep -q file"; then
     echo "enabling audit log ..."
-    vaultExec "vault audit enable file file_path=/vault/logs/audit.log"
+    vaultExec "vault audit enable file file_path=stdout"
   fi
 }
 


### PR DESCRIPTION
### What does this PR do?
fixes issue with vault audit log setup

this was actually never working on Openshift, but in previous commit, we've included `set -e` in script, so it started failing

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
run `./hack/vault-init.sh` on vault instance on OpenShift