### PR TITLE
Enhance logger output

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ type cliArgs struct {
 	ZapEncoder                     string                       `arg:"-e, --zap-encoder, env" default:"" help:"Zap log encoding (‘json’ or ‘console’)"`
 	ZapLogLevel                    string                       `arg:"-v, --zap-log-level, env" default:"" help:"Zap Level to configure the verbosity of logging"`
 	ZapStackTraceLevel             string                       `arg:"-s, --zap-stacktrace-level, env" default:"" help:"Zap Level at and above which stacktraces are captured"`
-	ZapTimeEncoding                string                       `arg:"-t, --zap-time-encoding, env" default:"rfc3339" help:"one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'"`
+	ZapTimeEncoding                string                       `arg:"-t, --zap-time-encoding, env" default:"iso8601" help:"one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'"`
 }
 
 func main() {

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -37,7 +37,7 @@ const (
 
 // InitDevelLoggers Configure zap backend development logger
 func InitDevelLoggers() {
-	InitLoggers(true, "", "", "", "rfc3339")
+	InitLoggers(true, "", "", "", "iso8601")
 }
 
 // InitLoggers Configure zap backend for controller-runtime logger.
@@ -57,7 +57,7 @@ func InitLoggers(development bool, encoder string, logLevel string, stackTraceLe
 	// set everything up such that we can use the same logger in controller runtime zap.L().*
 	logger := crzap.NewRaw(crzap.UseFlagOptions(&opts))
 	_ = zap.ReplaceGlobals(logger)
-	lg := zapr.NewLogger(logger)
+	lg := zapr.NewLogger(logger).WithCallDepth(1)
 	ctrl.SetLogger(lg)
 	klog.SetLoggerWithOptions(lg, klog.ContextualLogger(true))
 	hclog.SetDefault(NewHCLogAdapter(logger.WithOptions(zap.AddCallerSkip(1))))


### PR DESCRIPTION
### What does this PR do?
 - Used `iso8601` instead of `rfc3339` time format. 
 - Changed `CallDepth` for logr facade.

### Screenshot/screencast of this PR
Before
<img width="1701" alt="Знімок екрана 2022-07-21 о 12 19 22" src="https://user-images.githubusercontent.com/1614429/180180237-79c95b59-3e8d-448a-b90e-6e494d535cd3.png">
after

<img width="1713" alt="Знімок екрана 2022-07-21 о 12 16 20" src="https://user-images.githubusercontent.com/1614429/180180277-c00f5019-5de4-49ba-9cf1-bd5c04b1a6b4.png">


### What issues does this PR fix or reference?
 - To see milliseconds in logger output.
 - To see real caller method for `sigs.k8s.io/controller-runtime` and `k8s.io/klog/v2`

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
