### PR TITLE
Failure to perform docker login no longer fails the whole quay token lookup

### DIFF
--- a/pkg/serviceprovider/quay/metadataprovider.go
+++ b/pkg/serviceprovider/quay/metadataprovider.go
@@ -158,6 +158,11 @@ func (p metadataProvider) FetchRepo(ctx context.Context, repoUrl string, token *
 			return LoginTokenInfo{}, fmt.Errorf("fetch failed due to docker login error: %w", err)
 		}
 
+		// empty token means the credentials are no longer valid, which is not an error in and of itself
+		if tkn == "" {
+			return LoginTokenInfo{}, nil
+		}
+
 		info, err := AnalyzeLoginToken(tkn)
 		if err != nil {
 			lg.Error(err, "failed to analyze the docker login token")

--- a/pkg/serviceprovider/quay/state.go
+++ b/pkg/serviceprovider/quay/state.go
@@ -101,7 +101,7 @@ func fetchRepositoryRecord(ctx context.Context, cl *http.Client, repoUrl string,
 		return robotAccountRepositoryRecord(ctx, repoUrl, info)
 	} else {
 		// we're dealing with an oauth token
-		return oauthRepositoryRecord(ctx, cl, repoUrl, password, info)
+		return oauthRepositoryRecord(ctx, cl, repoUrl, password)
 	}
 }
 
@@ -166,7 +166,7 @@ func robotAccountRepositoryRecord(ctx context.Context, repository string, info L
 	}, nil
 }
 
-func oauthRepositoryRecord(ctx context.Context, cl *http.Client, repository string, token string, info LoginTokenInfo) (*EntityRecord, error) {
+func oauthRepositoryRecord(ctx context.Context, cl *http.Client, repository string, token string) (*EntityRecord, error) {
 	lg := log.FromContext(ctx)
 
 	rr := &EntityRecord{}


### PR DESCRIPTION
### What does this PR do?
`$TITLE`

This is a simple fix of the problem in the referenced issue. We should maybe think about introducing the validity checks of tokens in a more formal fashion in the workflow, but this fix would be required even with them, IMHO. So let's here first fix the issue and think about the validity checks at some later point in time.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-176

### How to test this PR?
See the repro steps in https://issues.redhat.com/browse/SVPI-176 . Instead of entering the irrecoverable error state, the re-created binding simply enters awaiting token data as expected.