### PR TITLE
Support robot tokens in Quay access check.

### DIFF
--- a/pkg/serviceprovider/quay/metadataprovider.go
+++ b/pkg/serviceprovider/quay/metadataprovider.go
@@ -77,7 +77,7 @@ func (p metadataProvider) Fetch(ctx context.Context, token *api.SPIAccessToken) 
 	if len(data.Username) > 0 {
 		metadata.Username = data.Username
 	} else {
-		metadata.Username = "$oauthtoken"
+		metadata.Username = OAuthTokenUserName
 	}
 
 	metadata.ServiceProviderState = js

--- a/pkg/serviceprovider/quay/state.go
+++ b/pkg/serviceprovider/quay/state.go
@@ -47,13 +47,14 @@ type TokenState struct {
 type Scope string
 
 const (
-	ScopeRepoRead   Scope = "repo:read"
-	ScopeRepoWrite  Scope = "repo:write"
-	ScopeRepoAdmin  Scope = "repo:admin"
-	ScopeRepoCreate Scope = "repo:create"
-	ScopeUserRead   Scope = "user:read"
-	ScopeUserAdmin  Scope = "user:admin"
-	ScopeOrgAdmin   Scope = "org:admin"
+	OAuthTokenUserName       = "$oauthtoken"
+	ScopeRepoRead      Scope = "repo:read"
+	ScopeRepoWrite     Scope = "repo:write"
+	ScopeRepoAdmin     Scope = "repo:admin"
+	ScopeRepoCreate    Scope = "repo:create"
+	ScopeUserRead      Scope = "user:read"
+	ScopeUserAdmin     Scope = "user:admin"
+	ScopeOrgAdmin      Scope = "org:admin"
 	// These are not real scopes in Quay, but we represent the permissions of the robot tokens with them
 	ScopePush Scope = "push"
 	ScopePull Scope = "pull"
@@ -96,7 +97,7 @@ func (s Scope) IsIncluded(scopes []Scope) bool {
 func fetchRepositoryRecord(ctx context.Context, cl *http.Client, repoUrl string, tokenData *api.Token, info LoginTokenInfo) (*EntityRecord, error) {
 	username, password := getUsernameAndPasswordFromTokenData(tokenData)
 
-	if username != "$oauthtoken" {
+	if username != OAuthTokenUserName {
 		// we're dealing with robot account
 		return robotAccountRepositoryRecord(ctx, repoUrl, info)
 	} else {
@@ -109,7 +110,7 @@ func getUsernameAndPasswordFromTokenData(tokenData *api.Token) (username, passwo
 	username = tokenData.Username
 
 	if username == "" {
-		username = "$oauthtoken"
+		username = OAuthTokenUserName
 	}
 
 	password = tokenData.AccessToken
@@ -123,7 +124,7 @@ func fetchOrganizationRecord(ctx context.Context, cl *http.Client, organization 
 
 	username, accessToken := getUsernameAndPasswordFromTokenData(tokenData)
 
-	if username != "$oauthtoken" {
+	if username != OAuthTokenUserName {
 		return nil, nil
 	}
 


### PR DESCRIPTION
### What does this PR do?
This refines the logic for figuring out the access to a Quay repository to support Quay's robot tokens.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-180

### How to test this PR?
1. Create a private repo in Quay. 
2. Create robot token that can read it.
3. Create a binding to that repo, requiring read access.
4. Manually upload the credentials to the linked token using the robot account creds from above.
5. Create SPIAccessCheck for reading that repo.
6. Check that SPIAccessCheck says that the repo is accessible and private.
