### PR TITLE
add new makefile target to deploy to openshift kcp workload with Route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ deploy_kcp: ensure-tmp manifests kustomize
 deploy_kcp_openshift: ensure-tmp manifests kustomize
 	if [ -z ${VAULT_HOST} ]; then echo "VAULT_HOST must be set"; exit 1; fi
 	$(eval KCP_WORKSPACE?=$(shell kubectl kcp workspace . --short))
-	KCP_WORKSPACE=$(KCP_WORKSPACE) SPIO_IMG=$(SPIO_IMG) SPIS_IMG=$(SPIS_IMG) hack/replace_placeholders_and_deploy.sh "${KUSTOMIZE}" "kcp_openshift" "kcp"
+	KCP_WORKSPACE=$(KCP_WORKSPACE) SPIO_IMG=$(SPIO_IMG) SPIS_IMG=$(SPIS_IMG) hack/replace_placeholders_and_deploy.sh "${KUSTOMIZE}" "kcp" "kcp_openshift"
 	kubectl apply -f .tmp/approle_secret.yaml -n spi-system
 	kubectl apply -f .tmp/deployment_kcp_openshift/kcp/apibinding_spi.yaml
 

--- a/config/kcp_openshift/kustomization.yaml
+++ b/config/kcp_openshift/kustomization.yaml
@@ -1,0 +1,8 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: spi-system
+
+resources:
+  - ../kcp
+  - route.yaml

--- a/config/kcp_openshift/route.yaml
+++ b/config/kcp_openshift/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: route
+  name: spi-oauth
 spec:
   port:
     targetPort: 8000

--- a/config/kcp_openshift/route.yaml
+++ b/config/kcp_openshift/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: route
+spec:
+  port:
+    targetPort: 8000
+  to:
+    kind: Service
+    # NOTE: Kustomize doesn't seem to know about routes, so we have to use the "rendered" name here, not just the name
+    # used in the kustomization, because kustomize would not replace it...
+    name: spi-oauth-service
+  tls:
+    termination: edge

--- a/hack/kcp-workload-apply.sh
+++ b/hack/kcp-workload-apply.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+NAME=${NAME:-spi-workload}
+
+kubectl apply -f .tmp/${NAME}.yaml

--- a/hack/kcp-workload-apply.sh
+++ b/hack/kcp-workload-apply.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-NAME=${NAME:-spi-workload}
+KCP_CLUSTER_NAME=${KCP_CLUSTER_NAME:-spi-workload}
 
-kubectl apply -f .tmp/${NAME}.yaml
+kubectl apply -f .tmp/${KCP_CLUSTER_NAME}.yaml

--- a/hack/kcp-workload-create-os.sh
+++ b/hack/kcp-workload-create-os.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-NAME=${NAME:-spi-workload}
+KCP_CLUSTER_NAME=${KCP_CLUSTER_NAME:-spi-workload}
 
 mkdir -p .tmp
 
-kubectl kcp workload sync ${NAME} \
+kubectl kcp workload sync ${KCP_CLUSTER_NAME} \
   --syncer-image ghcr.io/kcp-dev/kcp/syncer:release-0.7 \
-  --output-file=.tmp/${NAME}.yaml \
+  --output-file=.tmp/${KCP_CLUSTER_NAME}.yaml \
   --resources=services,routes.route.openshift.io

--- a/hack/kcp-workload-create-os.sh
+++ b/hack/kcp-workload-create-os.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+NAME=${NAME:-spi-workload}
+
+mkdir -p .tmp
+
+kubectl kcp workload sync ${NAME} \
+  --syncer-image ghcr.io/kcp-dev/kcp/syncer:release-0.7 \
+  --output-file=.tmp/${NAME}.yaml \
+  --resources=services,routes.route.openshift.io

--- a/hack/kcp-workload-create.sh
+++ b/hack/kcp-workload-create.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-NAME=${NAME:-spi-workload}
+KCP_CLUSTER_NAME=${KCP_CLUSTER_NAME:-spi-workload}
 
 mkdir -p .tmp
 
-kubectl kcp workload sync ${NAME} \
+kubectl kcp workload sync ${KCP_CLUSTER_NAME} \
   --syncer-image ghcr.io/kcp-dev/kcp/syncer:release-0.7 \
-  --output-file=.tmp/${NAME}.yaml \
+  --output-file=.tmp/${KCP_CLUSTER_NAME}.yaml \
   --resources=services

--- a/hack/kcp-workload-create.sh
+++ b/hack/kcp-workload-create.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+NAME=${NAME:-spi-workload}
+
+mkdir -p .tmp
+
+kubectl kcp workload sync ${NAME} \
+  --syncer-image ghcr.io/kcp-dev/kcp/syncer:release-0.7 \
+  --output-file=.tmp/${NAME}.yaml \
+  --resources=services


### PR DESCRIPTION
### What does this PR do?
 - new kustomize overlay `kcp_openshift` that includes the Route to oauth service
 - new makefile target `make deploy_kcp_openshift`, which deploys ^
 - add helper scripts to create and apply workload cluster to kcp, including one that sync Routes

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-138

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
 1. deploy to KCP with `make deploy_kcp_openshift`
 2. you must see the Route created with some URL generated in it
 3. you can enable debug logging for oauth service, so you see the requests in logs
 4. `curl` the route, with some path. You must see logs in oauth service with incoming requests