### PR TITLE
Fixed the name of the ConfigMap to patch

### DIFF
--- a/config/minikube/kustomization.yaml
+++ b/config/minikube/kustomization.yaml
@@ -10,7 +10,7 @@ patches:
   - target:
       version: v1
       kind: ConfigMap
-      name: shared-config
+      name: shared-environment-config
       namespace: system
     patch: |-
       - op: add


### PR DESCRIPTION
### What does this PR do?
Fixed the name of the ConfigMap to patch

### Screenshot/screencast of this PR
![Знімок екрана 2022-09-05 о 15 27 22](https://user-images.githubusercontent.com/1614429/188449660-0e548d28-ba9c-4acb-8e0e-6066ad927064.png)


### What issues does this PR fix or reference?
VAULTINSECURETLS is not set to true on minikube.

### How to test this PR?
- deploy on minikube
