### PR TITLE
kcp url for manual token upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ deploy_kcp_openshift: ensure-tmp manifests kustomize
 	$(eval KCP_WORKSPACE?=$(shell kubectl kcp workspace . --short))
 	KCP_WORKSPACE=$(KCP_WORKSPACE) SPIO_IMG=$(SPIO_IMG) SPIS_IMG=$(SPIS_IMG) hack/replace_placeholders_and_deploy.sh "${KUSTOMIZE}" "kcp" "kcp_openshift"
 	kubectl apply -f .tmp/approle_secret.yaml -n spi-system
-	kubectl apply -f .tmp/deployment_kcp_openshift/kcp/apibinding_spi.yaml
+	kubectl apply -f .tmp/deployment_kcp/kcp/apibinding_spi.yaml
 
 undeploy_k8s: undeploy_vault_k8s ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	if [ ! -d ${TEMP_DIR}/deployment_k8s ]; then echo "No deployment files found in .tmp/deployment_k8s"; exit 1; fi

--- a/config/kcp/clusterrolebinding.yaml
+++ b/config/kcp/clusterrolebinding.yaml
@@ -10,3 +10,6 @@ subjects:
 - kind: ServiceAccount
   name: controller-manager
   namespace: system
+- kind: ServiceAccount
+  name: oauth-sa
+  namespace: system

--- a/controllers/spiaccesscheck_controller.go
+++ b/controllers/spiaccesscheck_controller.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"time"
 
-	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/infrastructure"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 
@@ -51,14 +51,10 @@ type SPIAccessCheckReconciler struct {
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=spiaccesschecks/finalizers,verbs=update
 
 func (r *SPIAccessCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx = infrastructure.InitKcpControllerContext(ctx, req)
+
 	lg := log.FromContext(ctx)
 	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessCheck")
-
-	// if we're running on kcp, we need to include workspace name in context and logs
-	if req.ClusterName != "" {
-		ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(req.ClusterName))
-		lg = lg.WithValues("clusterName", req.ClusterName)
-	}
 
 	ac := api.SPIAccessCheck{}
 	if err := r.Get(ctx, req.NamespacedName, &ac); err != nil {

--- a/controllers/spiaccesstoken_controller.go
+++ b/controllers/spiaccesstoken_controller.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
-	"strings"
 	"time"
+
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/infrastructure"
 
 	"github.com/kcp-dev/logicalcluster/v2"
 
@@ -129,14 +130,10 @@ func requestsForTokenInObjectNamespace(object client.Object, tokenNameExtractor 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *SPIAccessTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx = infrastructure.InitKcpControllerContext(ctx, req)
+
 	lg := log.FromContext(ctx)
 	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessToken")
-
-	// if we're running on kcp, we need to include workspace name in context and logs
-	if req.ClusterName != "" {
-		ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(req.ClusterName))
-		lg = lg.WithValues("clusterName", req.ClusterName)
-	}
 
 	at := api.SPIAccessToken{}
 
@@ -298,10 +295,18 @@ func (r *SPIAccessTokenReconciler) fillInStatus(ctx context.Context, at *api.SPI
 		}
 	}
 	if at.Status.UploadUrl == "" {
-		at.Status.UploadUrl = strings.TrimSuffix(r.Configuration.BaseUrl, "/") + "/token/" + at.Namespace + "/" + at.Name
+		at.Status.UploadUrl = r.createUploadUrl(ctx, at)
 	}
 
 	return nil
+}
+
+func (r *SPIAccessTokenReconciler) createUploadUrl(ctx context.Context, at *api.SPIAccessToken) string {
+	if kcpWorkspaceName, hasKcpWorkspace := logicalcluster.ClusterFromContext(ctx); hasKcpWorkspace {
+		return fmt.Sprintf("%s/token/%s/%s/%s", r.Configuration.BaseUrl, kcpWorkspaceName.String(), at.Namespace, at.Name)
+	} else {
+		return fmt.Sprintf("%s/token/%s/%s", r.Configuration.BaseUrl, at.Namespace, at.Name)
+	}
 }
 
 // oAuthUrlFor determines the OAuth flow initiation URL for given token.
@@ -320,9 +325,15 @@ func (r *SPIAccessTokenReconciler) oAuthUrlFor(ctx context.Context, at *api.SPIA
 		return "", fmt.Errorf("failed to instantiate OAuth state codec: %w", err)
 	}
 
+	kcpWorkspace := ""
+	if kcpWorkspaceName, hasKcpWorkspace := logicalcluster.ClusterFromContext(ctx); hasKcpWorkspace {
+		kcpWorkspace = kcpWorkspaceName.String()
+	}
+
 	state, err := codec.Encode(&oauthstate.AnonymousOAuthState{
 		TokenName:           at.Name,
 		TokenNamespace:      at.Namespace,
+		TokenKcpWorkspace:   kcpWorkspace,
 		IssuedAt:            time.Now().Unix(),
 		Scopes:              sp.OAuthScopesFor(&at.Spec.Permissions),
 		ServiceProviderType: config.ServiceProviderType(sp.GetType()),

--- a/controllers/spiaccesstoken_controller_test.go
+++ b/controllers/spiaccesstoken_controller_test.go
@@ -20,20 +20,19 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v2"
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 	sconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreateUploadUrl(t *testing.T) {
-	cfg := &opconfig.OperatorConfiguration{
-		SharedConfiguration: sconfig.SharedConfiguration{
-			BaseUrl: "blabol",
-		},
-	}
 	r := &SPIAccessTokenReconciler{
-		Configuration: *cfg,
+		Configuration: config.OperatorConfiguration{
+			SharedConfiguration: sconfig.SharedConfiguration{
+				BaseUrl: "blabol",
+			},
+		},
 	}
 
 	at := &api.SPIAccessToken{

--- a/controllers/spiaccesstoken_controller_test.go
+++ b/controllers/spiaccesstoken_controller_test.go
@@ -1,3 +1,17 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controllers
 
 import (

--- a/controllers/spiaccesstoken_controller_test.go
+++ b/controllers/spiaccesstoken_controller_test.go
@@ -27,13 +27,13 @@ import (
 )
 
 func TestCreateUploadUrl(t *testing.T) {
-	cfg := opconfig.OperatorConfiguration{
+	cfg := &opconfig.OperatorConfiguration{
 		SharedConfiguration: sconfig.SharedConfiguration{
 			BaseUrl: "blabol",
 		},
 	}
 	r := &SPIAccessTokenReconciler{
-		Configuration: cfg,
+		Configuration: *cfg,
 	}
 
 	at := &api.SPIAccessToken{

--- a/controllers/spiaccesstoken_controller_test.go
+++ b/controllers/spiaccesstoken_controller_test.go
@@ -1,0 +1,47 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreateUploadUrl(t *testing.T) {
+	r := &SPIAccessTokenReconciler{
+		Configuration: opconfig.OperatorConfiguration{
+			SharedConfiguration: config.SharedConfiguration{
+				BaseUrl: "blabol",
+			},
+		},
+	}
+
+	at := &api.SPIAccessToken{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-namespace",
+			Name:      "test-atname",
+		},
+	}
+
+	t.Run("kcp-env", func(t *testing.T) {
+		ctx := logicalcluster.WithCluster(context.TODO(), logicalcluster.New("workspace"))
+		url := r.createUploadUrl(ctx, at)
+		assert.Contains(t, url, "blabol")
+		assert.Contains(t, url, "workspace")
+		assert.Contains(t, url, "test-namespace")
+		assert.Contains(t, url, "test-atname")
+	})
+
+	t.Run("non-kcp-env", func(t *testing.T) {
+		url := r.createUploadUrl(context.TODO(), at)
+		assert.Contains(t, url, "blabol")
+		assert.NotContains(t, url, "workspace")
+		assert.Contains(t, url, "test-namespace")
+		assert.Contains(t, url, "test-atname")
+	})
+}

--- a/controllers/spiaccesstoken_controller_test.go
+++ b/controllers/spiaccesstoken_controller_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v2"
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
+	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 	sconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +28,7 @@ import (
 
 func TestCreateUploadUrl(t *testing.T) {
 	r := &SPIAccessTokenReconciler{
-		Configuration: config.OperatorConfiguration{
+		Configuration: &opconfig.OperatorConfiguration{
 			SharedConfiguration: sconfig.SharedConfiguration{
 				BaseUrl: "blabol",
 			},

--- a/controllers/spiaccesstoken_controller_test.go
+++ b/controllers/spiaccesstoken_controller_test.go
@@ -21,18 +21,19 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+	sconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreateUploadUrl(t *testing.T) {
-	r := &SPIAccessTokenReconciler{
-		Configuration: opconfig.OperatorConfiguration{
-			SharedConfiguration: config.SharedConfiguration{
-				BaseUrl: "blabol",
-			},
+	cfg := opconfig.OperatorConfiguration{
+		SharedConfiguration: sconfig.SharedConfiguration{
+			BaseUrl: "blabol",
 		},
+	}
+	r := &SPIAccessTokenReconciler{
+		Configuration: cfg,
 	}
 
 	at := &api.SPIAccessToken{

--- a/controllers/spiaccesstokenbinding_controller.go
+++ b/controllers/spiaccesstokenbinding_controller.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 	"time"
 
-	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/infrastructure"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 
@@ -108,14 +108,10 @@ func (r *SPIAccessTokenBindingReconciler) SetupWithManager(mgr ctrl.Manager) err
 }
 
 func (r *SPIAccessTokenBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx = infrastructure.InitKcpControllerContext(ctx, req)
+
 	lg := log.FromContext(ctx)
 	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessTokenBinding")
-
-	// if we're running on kcp, we need to include workspace name in context and logs
-	if req.ClusterName != "" {
-		ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(req.ClusterName))
-		lg = lg.WithValues("clusterName", req.ClusterName)
-	}
 
 	binding := api.SPIAccessTokenBinding{}
 

--- a/controllers/spiaccesstokendataupdate_controller.go
+++ b/controllers/spiaccesstokendataupdate_controller.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/infrastructure"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 
@@ -52,14 +52,10 @@ func (r *SPIAccessTokenDataUpdateReconciler) SetupWithManager(mgr ctrl.Manager) 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *SPIAccessTokenDataUpdateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx = infrastructure.InitKcpControllerContext(ctx, req)
+
 	lg := log.FromContext(ctx)
 	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessTokenData")
-
-	// if we're running on kcp, we need to include workspace name in context and logs
-	if req.ClusterName != "" {
-		ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(req.ClusterName))
-		lg = lg.WithValues("clusterName", req.ClusterName)
-	}
 
 	update := api.SPIAccessTokenDataUpdate{}
 

--- a/pkg/infrastructure/kcp.go
+++ b/pkg/infrastructure/kcp.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -113,4 +115,14 @@ func restConfigForAPIExport(ctx context.Context, cfg *rest.Config, apiExportName
 	cfg.Host = apiExport.Status.VirtualWorkspaces[0].URL
 
 	return cfg, nil
+}
+
+func InitKcpControllerContext(ctx context.Context, req ctrl.Request) context.Context {
+	// if we're running on kcp, we need to include workspace name in context and logs
+	if req.ClusterName != "" {
+		ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(req.ClusterName))
+		ctx = log.IntoContext(ctx, log.FromContext(ctx, "clusterName", req.ClusterName))
+	}
+
+	return ctx
 }

--- a/pkg/infrastructure/kcp_test.go
+++ b/pkg/infrastructure/kcp_test.go
@@ -17,8 +17,10 @@ package infrastructure
 import (
 	"context"
 	"encoding/json"
+	"github.com/kcp-dev/logicalcluster/v2"
 	"net/http"
 	"net/http/httptest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"testing"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
@@ -87,6 +89,25 @@ func TestRestApiConfig(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, newRestConfig)
+	})
+}
+
+func TestInitKcpControllerContext(t *testing.T) {
+	t.Run("no workspace", func(t *testing.T) {
+		ctx := InitKcpControllerContext(context.TODO(), ctrl.Request{})
+
+		_, hasClusterName := logicalcluster.ClusterFromContext(ctx)
+		assert.False(t, hasClusterName)
+	})
+
+	t.Run("kcp workspace", func(t *testing.T) {
+		ctx := InitKcpControllerContext(context.TODO(), ctrl.Request{
+			ClusterName: "workspace",
+		})
+
+		clusterName, hasClusterName := logicalcluster.ClusterFromContext(ctx)
+		assert.True(t, hasClusterName)
+		assert.Equal(t, "workspace", clusterName.String())
 	})
 }
 

--- a/pkg/infrastructure/kcp_test.go
+++ b/pkg/infrastructure/kcp_test.go
@@ -17,11 +17,12 @@ package infrastructure
 import (
 	"context"
 	"encoding/json"
-	"github.com/kcp-dev/logicalcluster/v2"
 	"net/http"
 	"net/http/httptest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	"github.com/stretchr/testify/assert"

--- a/pkg/serviceprovider/github/github.go
+++ b/pkg/serviceprovider/github/github.go
@@ -88,7 +88,7 @@ func newGithub(factory *serviceprovider.Factory, _ string) (serviceprovider.Serv
 var _ serviceprovider.ConstructorFunc = newGithub
 
 func (g *Github) GetOAuthEndpoint() string {
-	return strings.TrimSuffix(g.Configuration.BaseUrl, "/") + "/github/authenticate"
+	return g.Configuration.BaseUrl + "/github/authenticate"
 }
 
 func (g *Github) GetBaseUrl() string {

--- a/pkg/serviceprovider/quay/quay.go
+++ b/pkg/serviceprovider/quay/quay.go
@@ -93,7 +93,7 @@ func newQuay(factory *serviceprovider.Factory, _ string) (serviceprovider.Servic
 var _ serviceprovider.ConstructorFunc = newQuay
 
 func (g *Quay) GetOAuthEndpoint() string {
-	return strings.TrimSuffix(g.Configuration.BaseUrl, "/") + "/quay/authenticate"
+	return g.Configuration.BaseUrl + "/quay/authenticate"
 }
 
 func (g *Quay) GetBaseUrl() string {

--- a/pkg/spi-shared/config/config.go
+++ b/pkg/spi-shared/config/config.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -109,7 +110,7 @@ func LoadFrom(args *CommonCliArgs) (SharedConfiguration, error) {
 	}
 
 	cfg := pcfg.convert()
-	cfg.BaseUrl = args.BaseUrl
+	cfg.BaseUrl = strings.TrimSuffix(args.BaseUrl, "/")
 
 	return cfg, nil
 }

--- a/pkg/spi-shared/config/config_test.go
+++ b/pkg/spi-shared/config/config_test.go
@@ -68,6 +68,23 @@ serviceProviders:
 	assert.Len(t, cfg.ServiceProviders, 2)
 }
 
+func TestBaseUrlIsTrimmed(t *testing.T) {
+	configFileContent := `
+sharedSecret: yaddayadda123$@#**
+serviceProviders:
+- type: GitHub
+  clientId: "123"
+  clientSecret: "42"
+`
+	cfgFilePath := createFile(t, "config", configFileContent)
+	defer os.Remove(cfgFilePath)
+
+	cfg, err := LoadFrom(&CommonCliArgs{ConfigFile: cfgFilePath, BaseUrl: "blabol/"})
+	assert.NoError(t, err)
+
+	assert.Equal(t, "blabol", cfg.BaseUrl)
+}
+
 func createFile(t *testing.T, path string, content string) string {
 	file, err := os.CreateTemp(os.TempDir(), path)
 	assert.NoError(t, err)

--- a/pkg/spi-shared/oauthstate/anonymous.go
+++ b/pkg/spi-shared/oauthstate/anonymous.go
@@ -39,6 +39,9 @@ type AnonymousOAuthState struct {
 	// TokenNamespace is the namespace of the SPIAccessToken object for which we are initiating the OAuth flow
 	TokenNamespace string `json:"tokenNamespace"`
 
+	// TokenKcpWorkspace is the KCP workspace where SPIAccessToken lives. It's empty in non-KCP environment
+	TokenKcpWorkspace string `json:"tokenKcpWorkspace"`
+
 	// IssuedAt is the timestamp when the state was generated.
 	IssuedAt int64 `json:"issuedAt,omitempty"`
 


### PR DESCRIPTION
### What does this PR do?
when running on kcp, add kcp workspace into upload url path and oauth state

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-92

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

image `quay.io/mvala/spi-operator:svpi138-kcpTokenUpload`

1. deploy on kcp
2. create `SPIAccessTokenBinding` or `SPIAccessToken` either in same workspace or in different workspace (you need to apply APIBinding in different workspace)
3. `status.uploadUrl` with workspace name must be set in both `SPIAccessToken` and `SPIAccessTokenBinding`