### PR TITLE
Use pointers to configuration so that it is updateable directly from the integration tests.

### DIFF
--- a/controllers/spiaccesscheck_controller.go
+++ b/controllers/spiaccesscheck_controller.go
@@ -43,7 +43,7 @@ type SPIAccessCheckReconciler struct {
 	client.Client
 	Scheme                 *runtime.Scheme
 	ServiceProviderFactory serviceprovider.Factory
-	Configuration          opconfig.OperatorConfiguration
+	Configuration          *opconfig.OperatorConfiguration
 }
 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=spiaccesschecks,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/spiaccesstoken_controller.go
+++ b/controllers/spiaccesstoken_controller.go
@@ -65,7 +65,7 @@ type SPIAccessTokenReconciler struct {
 	client.Client
 	Scheme                 *runtime.Scheme
 	TokenStorage           tokenstorage.TokenStorage
-	Configuration          opconfig.OperatorConfiguration
+	Configuration          *opconfig.OperatorConfiguration
 	ServiceProviderFactory serviceprovider.Factory
 	finalizers             finalizer.Finalizers
 }

--- a/controllers/spiaccesstokenbinding_controller.go
+++ b/controllers/spiaccesstokenbinding_controller.go
@@ -66,7 +66,7 @@ type SPIAccessTokenBindingReconciler struct {
 	client.Client
 	Scheme                 *runtime.Scheme
 	TokenStorage           tokenstorage.TokenStorage
-	Configuration          opconfig.OperatorConfiguration
+	Configuration          *opconfig.OperatorConfiguration
 	syncer                 sync.Syncer
 	ServiceProviderFactory serviceprovider.Factory
 }

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -67,7 +67,7 @@ type IntegrationTest struct {
 	TestServiceProvider      TestServiceProvider
 	HostCredsServiceProvider TestServiceProvider
 	VaultTestCluster         *vault.TestCluster
-	OperatorConfiguration    opconfig.OperatorConfiguration
+	OperatorConfiguration    *opconfig.OperatorConfiguration
 }
 
 var ITest IntegrationTest
@@ -166,7 +166,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	ITest.OperatorConfiguration = opconfig.OperatorConfiguration{
+	ITest.OperatorConfiguration = &opconfig.OperatorConfiguration{
 		SharedConfiguration: config.SharedConfiguration{
 			ServiceProviders: []config.ServiceProviderConfiguration{
 				{

--- a/main.go
+++ b/main.go
@@ -93,13 +93,13 @@ func main() {
 		Scheme:       mgr.GetScheme(),
 		TokenStorage: strg,
 		ServiceProviderFactory: serviceprovider.Factory{
-			Configuration:    cfg,
+			Configuration:    &cfg,
 			KubernetesClient: mgr.GetClient(),
 			HttpClient:       http.DefaultClient,
 			Initializers:     serviceproviders.KnownInitializers(),
 			TokenStorage:     strg,
 		},
-		Configuration: cfg,
+		Configuration: &cfg,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SPIAccessToken")
 		os.Exit(1)
@@ -109,13 +109,13 @@ func main() {
 		Scheme:       mgr.GetScheme(),
 		TokenStorage: strg,
 		ServiceProviderFactory: serviceprovider.Factory{
-			Configuration:    cfg,
+			Configuration:    &cfg,
 			KubernetesClient: mgr.GetClient(),
 			HttpClient:       http.DefaultClient,
 			Initializers:     serviceproviders.KnownInitializers(),
 			TokenStorage:     strg,
 		},
-		Configuration: cfg,
+		Configuration: &cfg,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SPIAccessTokenBinding")
 		os.Exit(1)
@@ -125,13 +125,13 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		ServiceProviderFactory: serviceprovider.Factory{
-			Configuration:    cfg,
+			Configuration:    &cfg,
 			KubernetesClient: mgr.GetClient(),
 			HttpClient:       http.DefaultClient,
 			Initializers:     serviceproviders.KnownInitializers(),
 			TokenStorage:     strg,
 		},
-		Configuration: cfg,
+		Configuration: &cfg,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SPIAccessCheck")
 		os.Exit(1)

--- a/pkg/serviceprovider/github/github.go
+++ b/pkg/serviceprovider/github/github.go
@@ -44,7 +44,7 @@ var (
 )
 
 type Github struct {
-	Configuration   opconfig.OperatorConfiguration
+	Configuration   *opconfig.OperatorConfiguration
 	lookup          serviceprovider.GenericLookup
 	httpClient      rest.HTTPClient
 	tokenStorage    tokenstorage.TokenStorage

--- a/pkg/serviceprovider/hostcredentials/hostcredentials.go
+++ b/pkg/serviceprovider/hostcredentials/hostcredentials.go
@@ -31,7 +31,7 @@ import (
 // manual upload of token data. Matching is done only by URL of the provider, so it is possible to have
 // only one token for particular URL in the given namespace.
 type HostCredentialsProvider struct {
-	Configuration opconfig.OperatorConfiguration
+	Configuration *opconfig.OperatorConfiguration
 	lookup        serviceprovider.GenericLookup
 	httpClient    rest.HTTPClient
 	repoUrl       string

--- a/pkg/serviceprovider/quay/quay.go
+++ b/pkg/serviceprovider/quay/quay.go
@@ -47,7 +47,7 @@ var (
 )
 
 type Quay struct {
-	Configuration    opconfig.OperatorConfiguration
+	Configuration    *opconfig.OperatorConfiguration
 	lookup           serviceprovider.GenericLookup
 	metadataProvider *metadataProvider
 	httpClient       rest.HTTPClient

--- a/pkg/serviceprovider/quay/quay_test.go
+++ b/pkg/serviceprovider/quay/quay_test.go
@@ -81,7 +81,7 @@ func TestMapToken(t *testing.T) {
 	}
 
 	fac := &serviceprovider.Factory{
-		Configuration: opconfig.OperatorConfiguration{
+		Configuration: &opconfig.OperatorConfiguration{
 			TokenLookupCacheTtl: 100 * time.Hour,
 		},
 		KubernetesClient: k8sClient,

--- a/pkg/serviceprovider/serviceprovider.go
+++ b/pkg/serviceprovider/serviceprovider.go
@@ -79,7 +79,7 @@ type ValidationResult struct {
 
 // Factory is able to construct service providers from repository URLs.
 type Factory struct {
-	Configuration    opconfig.OperatorConfiguration
+	Configuration    *opconfig.OperatorConfiguration
 	KubernetesClient client.Client
 	HttpClient       *http.Client
 	Initializers     map[config.ServiceProviderType]Initializer

--- a/pkg/serviceprovider/serviceprovider_test.go
+++ b/pkg/serviceprovider/serviceprovider_test.go
@@ -137,7 +137,7 @@ func TestFromRepoUrl(t *testing.T) {
 	}
 
 	fact := Factory{
-		Configuration:    opconfig.OperatorConfiguration{},
+		Configuration:    &opconfig.OperatorConfiguration{},
 		KubernetesClient: nil,
 		HttpClient:       nil,
 		Initializers: map[config.ServiceProviderType]Initializer{


### PR DESCRIPTION
### What does this PR do?
To be able to update the configuration in the integration tests during the lifetime of the controllers, we need to make sure the integration tests and the controllers all use the same instance, i.e. use pointers.


### What issues does this PR fix or reference?
none
