### PR TITLE
kcp - allow all authenticated users to bind to spi apiexport

### DIFF
--- a/config/kcp/apiexport_spi_clusterrole.yaml
+++ b/config/kcp/apiexport_spi_clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: apiexport-spi
+rules:
+- apiGroups:
+  - apis.kcp.dev
+  resourceNames:
+  - spi
+  resources:
+  - apiexports
+  verbs:
+  - bind

--- a/config/kcp/apiexport_spi_clusterrolebinding.yaml
+++ b/config/kcp/apiexport_spi_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: apiexport-spi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: apiexport-spi
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated

--- a/config/kcp/kustomization.yaml
+++ b/config/kcp/kustomization.yaml
@@ -6,6 +6,8 @@ namespace: spi-system
 resources:
   - apiexport_spi.yaml
   - apiresourceschema_spi.yaml
+  - apiexport_spi_clusterrole.yaml
+  - apiexport_spi_clusterrolebinding.yaml
   - clusterrole.yaml
   - clusterrolebinding.yaml
   - ../default


### PR DESCRIPTION
### What does this PR do?
kcp now need explicitly set RBAC rules to allow binding to the APIExport. This allows all authenticated users to bind to spi api

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

1. deploy to kcp
2. apibinding must be created fine, check with `k get apibindings.apis.kcp.dev spi-binding -o yaml` (before this patch, it failed with not enough permissions to bind to apiexport)