### PR TITLE
Implement Vault login token renewal

### DIFF
--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -195,13 +195,15 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	var strg tokenstorage.TokenStorage
-	ITest.VaultTestCluster, strg = tokenstorage.CreateTestVaultTokenStorage(GinkgoT())
+	ITest.VaultTestCluster, strg, _, _ = tokenstorage.CreateTestVaultTokenStorageWithAuth(GinkgoT())
 	Expect(err).NotTo(HaveOccurred())
 
 	ITest.TokenStorage = &tokenstorage.NotifyingTokenStorage{
 		Client:       cl,
 		TokenStorage: strg,
 	}
+
+	Expect(ITest.TokenStorage.Initialize(ctx)).To(Succeed())
 
 	factory := serviceprovider.Factory{
 		Configuration:    ITest.OperatorConfiguration,

--- a/pkg/serviceprovider/quay/quay_test.go
+++ b/pkg/serviceprovider/quay/quay_test.go
@@ -358,7 +358,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 			},
 		},
 	}
-	ts := tokenStorageMock{getFunc: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+	ts := tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 		return &api.Token{AccessToken: "blabol"}, nil
 	}}
 
@@ -573,7 +573,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusUnauthorized}, nil
 			}},
 			lookup: lookupMock,
-			tokenStorage: tokenStorageMock{getFunc: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+			tokenStorage: tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 				return nil, nil
 			}},
 		}
@@ -596,7 +596,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(publicRepoResponseJson))}, nil
 			}},
 			lookup: lookupMock,
-			tokenStorage: tokenStorageMock{getFunc: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+			tokenStorage: tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 				return nil, nil
 			}},
 		}
@@ -619,7 +619,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusUnauthorized}, nil
 			}},
 			lookup: lookupMock,
-			tokenStorage: tokenStorageMock{getFunc: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+			tokenStorage: tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 				return &api.Token{AccessToken: "tkn", Username: "alois"}, nil
 			}},
 		}
@@ -658,20 +658,4 @@ type tokenFilterMock struct {
 
 func (t tokenFilterMock) Matches(ctx context.Context, matchable serviceprovider.Matchable, token *api.SPIAccessToken) (bool, error) {
 	return t.matchesFunc(ctx, matchable, token)
-}
-
-type tokenStorageMock struct {
-	getFunc func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error)
-}
-
-func (t tokenStorageMock) Store(ctx context.Context, owner *api.SPIAccessToken, token *api.Token) error {
-	return nil
-}
-
-func (t tokenStorageMock) Get(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
-	return t.getFunc(ctx, owner)
-}
-
-func (t tokenStorageMock) Delete(ctx context.Context, owner *api.SPIAccessToken) error {
-	return nil
 }

--- a/pkg/spi-shared/tokenstorage/notifyingtokenstorage.go
+++ b/pkg/spi-shared/tokenstorage/notifyingtokenstorage.go
@@ -33,6 +33,13 @@ type NotifyingTokenStorage struct {
 	TokenStorage TokenStorage
 }
 
+func (n NotifyingTokenStorage) Initialize(ctx context.Context) error {
+	if err := n.TokenStorage.Initialize(ctx); err != nil {
+		return fmt.Errorf("wrapped storage error: %w", err)
+	}
+	return nil
+}
+
 func (n NotifyingTokenStorage) Store(ctx context.Context, owner *api.SPIAccessToken, token *api.Token) error {
 	if err := n.TokenStorage.Store(ctx, owner, token); err != nil {
 		return fmt.Errorf("wrapped storage error: %w", err)

--- a/pkg/spi-shared/tokenstorage/secrets.go
+++ b/pkg/spi-shared/tokenstorage/secrets.go
@@ -40,6 +40,10 @@ func NewSecretsStorage(cl client.Client) (TokenStorage, error) {
 	return &secretsTokenStorage{Client: cl, syncer: sync.New(cl)}, nil
 }
 
+func (s secretsTokenStorage) Initialize(_ context.Context) error {
+	return nil
+}
+
 func (s secretsTokenStorage) Store(ctx context.Context, owner *api.SPIAccessToken, token *api.Token) error {
 	data := map[string][]byte{
 		"username":      []byte(token.Username),

--- a/pkg/spi-shared/tokenstorage/tokenstorage.go
+++ b/pkg/spi-shared/tokenstorage/tokenstorage.go
@@ -23,6 +23,7 @@ import (
 // TokenStorage is a simple interface on top of Kubernetes client to perform CRUD operations on the tokens. This is done
 // so that we can provide either secret-based or Vault-based implementation.
 type TokenStorage interface {
+	Initialize(ctx context.Context) error
 	Store(ctx context.Context, owner *api.SPIAccessToken, token *api.Token) error
 	Get(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error)
 	Delete(ctx context.Context, owner *api.SPIAccessToken) error

--- a/pkg/spi-shared/tokenstorage/vault_login.go
+++ b/pkg/spi-shared/tokenstorage/vault_login.go
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenstorage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type loginHandler struct {
+	client     *vault.Client
+	authMethod vault.AuthMethod
+}
+
+// Login tries to log in to Vault and starts a background routine to renew the login token.
+func (h loginHandler) Login(ctx context.Context) error {
+	// we make the first login attempt in a blocking fashion so that we can bail out quickly if it is not possible.
+	authInfo, err := h.doLogin(ctx)
+	if err != nil {
+		return err
+	}
+
+	go h.loginLoop(ctx, authInfo)
+
+	return nil
+}
+
+// loginLoop basically calls startRenew in an infinite loop, trying to re-login if startRenew tells it to.
+func (h loginHandler) loginLoop(ctx context.Context, authInfo *vault.Secret) {
+	lg := log.FromContext(ctx, "vaultLoginHandler", true)
+	getRenewableTokenBackoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Steps:    10,
+	}
+
+	attemptsToGetRenewableToken := getRenewableTokenBackoff
+	for {
+		var err error
+
+		if authInfo == nil || !authInfo.Auth.Renewable {
+			lg.V(logs.DebugLevel).Info("token not renewable, reattempting login")
+
+			authInfo, err = h.doLogin(ctx)
+			if err != nil {
+				lg.Error(err, "failed to login to vault after detecting the current token is not renewable")
+			}
+
+			time.Sleep(attemptsToGetRenewableToken.Step())
+			continue
+		} else {
+			attemptsToGetRenewableToken = getRenewableTokenBackoff
+		}
+
+		// ok, we have a renewable token
+		var reLogin bool
+		reLogin, err = h.startRenew(ctx, authInfo)
+		if err != nil {
+			lg.Error(err, "failed to run the Vault token renewal routine")
+		}
+		if !reLogin {
+			return
+		}
+
+		authInfo, err = h.doLogin(ctx)
+		if err != nil {
+			lg.Error(err, "failed to login to Vault")
+		}
+	}
+}
+
+// doLogin performs a single login attempt and, after some basic error checking, returns the vault secret
+func (h loginHandler) doLogin(ctx context.Context) (*vault.Secret, error) {
+	authInfo, err := h.client.Auth().Login(ctx, h.authMethod)
+	if err != nil {
+		return nil, fmt.Errorf("error while authenticating: %w", err)
+	}
+	if authInfo == nil {
+		return nil, noAuthInfoInVaultError
+	}
+
+	return authInfo, nil
+}
+
+// startRenew takes care of renewing the Vault token. This only returns in case of error or if a new login attempt
+// needs to be made. Returns true if the re-login is possible, false if no more login attempts should be made (if the
+// context is done).
+func (h loginHandler) startRenew(ctx context.Context, secret *vault.Secret) (bool, error) {
+	watcher, err := h.client.NewLifetimeWatcher(&vault.LifetimeWatcherInput{
+		Secret: secret,
+	})
+	if err != nil {
+		return true, fmt.Errorf("failed to construct Vault token lifetime watcher: %w", err)
+	}
+
+	lg := log.FromContext(ctx)
+
+	go watcher.Start()
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			lg.Info("stopping the Vault token renewal routine because the context is done")
+			return false, nil
+		case err = <-watcher.DoneCh():
+			return true, err
+		case <-watcher.RenewCh():
+			lg.V(logs.DebugLevel).Info("successfully renewed the Vault token")
+		}
+	}
+}

--- a/pkg/spi-shared/tokenstorage/vault_login_test.go
+++ b/pkg/spi-shared/tokenstorage/vault_login_test.go
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenstorage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/api/auth/approle"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVaultLogin_Renewal(t *testing.T) {
+
+	cluster, ts, roleId, secretId := CreateTestVaultTokenStorageWithAuth(t)
+	defer cluster.Cleanup()
+
+	rootClient := cluster.Cores[0].Client
+	_, err := rootClient.Logical().Write("/auth/approle/role/test-role", map[string]interface{}{"token_ttl": "1s"})
+	assert.NoError(t, err)
+
+	auth, err := approle.NewAppRoleAuth(roleId, &approle.SecretID{FromString: secretId})
+	assert.NoError(t, err)
+
+	vts := ts.(*vaultTokenStorage)
+	origToken := vts.Token()
+	assert.NotNil(t, vts.loginHandler)
+	assert.Equal(t, auth, vts.loginHandler.authMethod)
+	assert.NoError(t, ts.Initialize(context.TODO()))
+
+	time.Sleep(2 * time.Second)
+
+	assert.NotEqual(t, origToken, vts.Token())
+
+	assert.NoError(t, ts.Store(context.TODO(), testSpiAccessToken, testToken))
+
+	expiredClientCfg := vault.DefaultConfig()
+	expiredClientCfg.Address = ts.(*vaultTokenStorage).Client.Address()
+	assert.NoError(t, expiredClientCfg.ConfigureTLS(&vault.TLSConfig{
+		Insecure: true,
+	}))
+	expiredClient, err := vault.NewClient(expiredClientCfg)
+	assert.NoError(t, err)
+	expiredClient.SetToken(origToken)
+
+	notRenewingTokenStorage := &vaultTokenStorage{
+		Client: expiredClient,
+	}
+	assert.Error(t, notRenewingTokenStorage.Store(context.TODO(), testSpiAccessToken, testToken))
+}


### PR DESCRIPTION
### What does this PR do?
When a client logs in to Vault, it obtains a "login token" that is used to authenticate the subsequent requests. This token has a TTL associated with it and by default it is refreshable. This PR implements logic to refresh this login token so that the operator can access Vault even with short lived login tokens.

Note that this is completely separate from any TTL associated with the secret ID of the Approle authentication method.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-204

### How to test this PR?
1. deploy using the images from the current main branch - `make deploy_minikube`
2. set-up the default SA to be able to work with SPI objects: `kubectl apply -f hack/give-default-sa-perms-for-accesstokens.yaml`
3. create a binding and a token `kubectl apply -f samples/binding-read-repo-quay.yaml`
4. set the maximum token ttl to 1 minute - `kubectl exec -n spi-vault -t vault-0 -- vault write sys/auth/approle/tune max_lease_ttl=1m default_lease_ttl=1m`
5. restart the deployments to obtain the new short-lived login token - `kubectl -n spi-system scale deployment spi-controller-manager spi-oauth-service --replicas=0 && kubectl -n spi-system scale deployment spi-controller-manager spi-oauth-service --replicas=1`
6. wait 2 minutes
7. try to manually upload a token - `curl -kv -H "Authorization: Bearer $(./hack/get-default-sa-token.sh)" $(kc get spiaccesstokenbinding binding-read-repository -o jsonpath='{.status.uploadUrl}') -d '{"access_token":"tooken", "username": "kachny"}'`
8. Observe a 403 response
9. update the oauth service image to the one with the fix in this PR - `kubectl -n spi-system patch deployment spi-oauth-service --type=json -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "quay.io/lkrejci/service-provider-integration-oauth:token-refresh"}]'`
10. wait for the oauth service deployment to restart
11. wait 2 minutes
12. repeat the manual upload attempt
13. observe the success (204 status)