### PR TITLE
fix kcp apibinding accept secret permission claims

### DIFF
--- a/config/kcp/apibinding_spi.yaml
+++ b/config/kcp/apibinding_spi.yaml
@@ -7,6 +7,6 @@ spec:
     workspace:
       path: ${KCP_WORKSPACE}
       exportName: spi
-  acceptedPermissionClaims:
-    - group: ""
-      resource: secrets
+  permissionClaims:
+    - resource: secrets
+      state: Accepted


### PR DESCRIPTION
### What does this PR do?
fixes issue with getting secrets in kcp env. KCP silently changed APIBinding definition...

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->
https://issues.redhat.com/browse/SVPI-203

### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
1. create spiaccesstokenbinding with generic serviceprovider
2. manually upload the token
3. secret should be created fine, with no "secret not found" error
