### PR TITLE
Simplify the OAuth state in the URL.

### DIFF
--- a/config/k8s/config.yaml
+++ b/config/k8s/config.yaml
@@ -1,4 +1,3 @@
-sharedSecret: ${SHARED_SECRET}
 serviceProviders:
 - type: GitHub
   clientId: "123"

--- a/config/kcp/config.yaml
+++ b/config/kcp/config.yaml
@@ -1,4 +1,3 @@
-sharedSecret: ${SHARED_SECRET}
 serviceProviders:
 - type: GitHub
   clientId: "123"

--- a/config/openshift-example/config.yaml
+++ b/config/openshift-example/config.yaml
@@ -1,4 +1,3 @@
-sharedSecret: ${SHARED_SECRET}
 serviceProviders:
   - type: GitHub
     clientId: "123"

--- a/controllers/spiaccesstoken_controller.go
+++ b/controllers/spiaccesstoken_controller.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/infrastructure"
 
 	"github.com/kcp-dev/logicalcluster/v2"
@@ -324,10 +326,12 @@ func (r *SPIAccessTokenReconciler) oAuthUrlFor(ctx context.Context, at *api.SPIA
 	}
 
 	state, err := oauthstate.Encode(&oauthstate.OAuthInfo{
-		TokenName:         at.Name,
-		TokenNamespace:    at.Namespace,
-		TokenKcpWorkspace: kcpWorkspace,
-		Scopes:            sp.OAuthScopesFor(&at.Spec.Permissions),
+		TokenName:           at.Name,
+		TokenNamespace:      at.Namespace,
+		TokenKcpWorkspace:   kcpWorkspace,
+		Scopes:              sp.OAuthScopesFor(&at.Spec.Permissions),
+		ServiceProviderType: config.ServiceProviderType(sp.GetType()),
+		ServiceProviderUrl:  sp.GetBaseUrl(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to encode the OAuth state: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/alexflint/go-arg v1.4.3
-	github.com/go-jose/go-jose/v3 v3.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
 	github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,6 @@ github.com/go-errors/errors v1.4.1 h1:IvVlgbzSsaUNudsw5dcXSzF3EWyXTi5XrAdngnuhRy
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
-github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -1246,7 +1244,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/hack/multi-cluster/minikube.sh
+++ b/hack/multi-cluster/minikube.sh
@@ -11,9 +11,6 @@ SPIS_IMG=${SPIS_IMG:=quay.io/redhat-appstudio/service-provider-integration-oauth
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
-# the shared secret set in the configuration of SPI in both clusters
-SHARED_SECRET="kachny"
-
 # change the directory so that we can run make
 cd "$SCRIPT_DIR/../.." || exit 1
 

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -175,7 +175,6 @@ var _ = BeforeSuite(func() {
 					ServiceProviderType: "TestServiceProvider",
 				},
 			},
-			SharedSecret: []byte("secret"),
 		},
 		AccessCheckTtl:        10 * time.Second,
 		AccessTokenTtl:        10 * time.Second,

--- a/pkg/spi-shared/config/config.go
+++ b/pkg/spi-shared/config/config.go
@@ -54,9 +54,6 @@ type CommonCliArgs struct {
 type persistedConfiguration struct {
 	// ServiceProviders is the list of configuration options for the individual service providers
 	ServiceProviders []ServiceProviderConfiguration `yaml:"serviceProviders"`
-
-	// SharedSecret is secret value used for signing the JWT keys.
-	SharedSecret string `yaml:"sharedSecret"`
 }
 
 // SharedConfiguration contains the specification of the known service providers as well as other configuration data shared
@@ -68,9 +65,6 @@ type SharedConfiguration struct {
 	// BaseUrl is the URL on which the OAuth service is deployed. It is used to compose the redirect URLs for the
 	// service providers in the form of `${BASE_URL}/${SP_TYPE}/callback` (e.g. my-host/github/callback).
 	BaseUrl string
-
-	// SharedSecret is the secret value used for signing the JWT keys used as OAuth state.
-	SharedSecret []byte
 }
 
 // ServiceProviderConfiguration contains configuration for a single service provider configured with the SPI. This
@@ -99,7 +93,6 @@ func (c persistedConfiguration) convert() SharedConfiguration {
 	conf := SharedConfiguration{}
 
 	conf.ServiceProviders = c.ServiceProviders
-	conf.SharedSecret = []byte(c.SharedSecret)
 	return conf
 }
 

--- a/pkg/spi-shared/config/config_test.go
+++ b/pkg/spi-shared/config/config_test.go
@@ -48,7 +48,6 @@ users:
 	defer os.Remove(kcfgFilePath)
 
 	configFileContent := `
-sharedSecret: yaddayadda123$@#**
 serviceProviders:
 - type: GitHub
   clientId: "123"
@@ -64,13 +63,11 @@ serviceProviders:
 	assert.NoError(t, err)
 
 	assert.Equal(t, "blabol", cfg.BaseUrl)
-	assert.Equal(t, []byte("yaddayadda123$@#**"), cfg.SharedSecret)
 	assert.Len(t, cfg.ServiceProviders, 2)
 }
 
 func TestBaseUrlIsTrimmed(t *testing.T) {
 	configFileContent := `
-sharedSecret: yaddayadda123$@#**
 serviceProviders:
 - type: GitHub
   clientId: "123"

--- a/pkg/spi-shared/oauthstate/anonymous.go
+++ b/pkg/spi-shared/oauthstate/anonymous.go
@@ -15,6 +15,8 @@ package oauthstate
 
 import (
 	"fmt"
+
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 )
 
 // OAuthInfo is the state that is initially put to the OAuth URL by the operator.
@@ -33,6 +35,12 @@ type OAuthInfo struct {
 
 	// Scopes is the list of the service-provider-specific scopes that we require in the service provider
 	Scopes []string `json:"scopes"`
+
+	// ServiceProviderType is the type of the service provider
+	ServiceProviderType config.ServiceProviderType `json:"serviceProviderType"`
+
+	// ServiceProviderUrl the URL where the service provider is to be reached
+	ServiceProviderUrl string `json:"serviceProviderUrl"`
 }
 
 // ParseOAuthInfo parses the state from the URL query parameter and returns the anonymous state struct. It is just

--- a/pkg/spi-shared/oauthstate/codec_test.go
+++ b/pkg/spi-shared/oauthstate/codec_test.go
@@ -16,56 +16,27 @@ package oauthstate
 
 import (
 	"testing"
-	"time"
 
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAnonymous(t *testing.T) {
-	codec := getCodec(t)
-
-	t.Run("valid", func(t *testing.T) {
-		encoded, err := codec.Encode(&AnonymousOAuthState{
-			TokenName:           "token-name",
-			TokenNamespace:      "default",
-			IssuedAt:            0,
-			Scopes:              []string{"a", "b", "c"},
-			ServiceProviderType: "sp type",
-			ServiceProviderUrl:  "https://sp",
-		})
-		assert.NoError(t, err)
-
-		decoded, err := codec.ParseAnonymous(encoded)
-		assert.NoError(t, err)
-
-		assert.Equal(t, "token-name", decoded.TokenName)
-		assert.Equal(t, "default", decoded.TokenNamespace)
-		assert.Equal(t, int64(0), decoded.IssuedAt)
-		assert.Equal(t, []string{"a", "b", "c"}, decoded.Scopes)
-		assert.Equal(t, config.ServiceProviderType("sp type"), decoded.ServiceProviderType)
-		assert.Equal(t, "https://sp", decoded.ServiceProviderUrl)
+	encoded, err := Encode(&OAuthInfo{
+		TokenName:      "token-name",
+		TokenNamespace: "default",
+		Scopes:         []string{"a", "b", "c"},
 	})
+	assert.NoError(t, err)
 
-	t.Run("invalid", func(t *testing.T) {
-		encoded, err := codec.Encode(&AnonymousOAuthState{
-			TokenName:           "token-name",
-			TokenNamespace:      "default",
-			IssuedAt:            time.Now().Add(1 * time.Hour).Unix(),
-			Scopes:              nil,
-			ServiceProviderType: "sp type",
-			ServiceProviderUrl:  "https://sp",
-		})
-		assert.NoError(t, err)
+	decoded, err := ParseOAuthInfo(encoded)
+	assert.NoError(t, err)
 
-		_, err = codec.ParseAnonymous(encoded)
-		assert.Error(t, err)
-	})
+	assert.Equal(t, "token-name", decoded.TokenName)
+	assert.Equal(t, "default", decoded.TokenNamespace)
+	assert.Equal(t, []string{"a", "b", "c"}, decoded.Scopes)
 }
 
 func TestCustom(t *testing.T) {
-	codec := getCodec(t)
-
 	type Custom struct {
 		Data string
 	}
@@ -75,31 +46,25 @@ func TestCustom(t *testing.T) {
 	}
 
 	t.Run("valid", func(t *testing.T) {
-		encoded, err := codec.Encode(&Custom{
+		encoded, err := Encode(&Custom{
 			Data: "42",
 		})
 		assert.NoError(t, err)
 
 		decoded := &Custom{}
-		err = codec.ParseInto(encoded, decoded)
+		err = ParseInto(encoded, decoded)
 		assert.NoError(t, err)
 
 		assert.Equal(t, "42", decoded.Data)
 	})
 
 	t.Run("wrong type", func(t *testing.T) {
-		encoded, err := codec.Encode(&Invalid{})
+		encoded, err := Encode(&Invalid{})
 		assert.NoError(t, err)
 
 		decoded := &Custom{}
-		err = codec.ParseInto(encoded, decoded)
+		err = ParseInto(encoded, decoded)
 		assert.NoError(t, err)
 		assert.Empty(t, decoded.Data)
 	})
-}
-
-func getCodec(t *testing.T) Codec {
-	ret, err := NewCodec([]byte("secret"))
-	assert.NoError(t, err)
-	return ret
 }

--- a/pkg/spi-shared/oauthstate/codec_test.go
+++ b/pkg/spi-shared/oauthstate/codec_test.go
@@ -17,14 +17,18 @@ package oauthstate
 import (
 	"testing"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAnonymous(t *testing.T) {
 	encoded, err := Encode(&OAuthInfo{
-		TokenName:      "token-name",
-		TokenNamespace: "default",
-		Scopes:         []string{"a", "b", "c"},
+		TokenName:           "token-name",
+		TokenNamespace:      "default",
+		Scopes:              []string{"a", "b", "c"},
+		ServiceProviderType: "sp type",
+		ServiceProviderUrl:  "https://sp",
 	})
 	assert.NoError(t, err)
 
@@ -34,6 +38,8 @@ func TestAnonymous(t *testing.T) {
 	assert.Equal(t, "token-name", decoded.TokenName)
 	assert.Equal(t, "default", decoded.TokenNamespace)
 	assert.Equal(t, []string{"a", "b", "c"}, decoded.Scopes)
+	assert.Equal(t, config.ServiceProviderType("sp type"), decoded.ServiceProviderType)
+	assert.Equal(t, "https://sp", decoded.ServiceProviderUrl)
 }
 
 func TestCustom(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Simplify the OAuth state in the URL.

Now it is just url-safe base64 encoded json.

This enabled us to remove the sharedSecret from the configuration, which, given our other security measures during the OAuth flow, no longer offered any additional security benefits.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-206

### How to test this PR?
1. `make install deploy_minikube SPIO_IMG=quay.io/lkrejci/service-provider-integration-operator:stable-oauth-url SPIS_IMG=quay.io/lkrejci/service-provider-integration-oauth:stable-oauth-url`
2. Configure github or quay service provider with OAuth app details
3. create a binding for github or quay repo
4. OAuth URL should work