### PR TITLE
fix: spiaccesstokencontroller integration test

### DIFF
--- a/integration_tests/spiaccessbindingcontroller_test.go
+++ b/integration_tests/spiaccessbindingcontroller_test.go
@@ -628,7 +628,7 @@ var _ = Describe("Status updates", func() {
 				g.Expect(binding.Status.ErrorReason).To(Equal(api.SPIAccessTokenBindingErrorReasonUnknownServiceProviderType))
 				g.Expect(binding.Status.LinkedAccessTokenName).To(BeEmpty())
 			}).Should(Succeed())
-			ITest.TestServiceProvider.Reset()
+			ITest.HostCredsServiceProvider.Reset()
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Pavol Baran <pbaran@redhat.com>

### What does this PR do?
Because HostCredsServiceProvider was not reset in the test, it caused a different test to use the wrong implementation of the GetBaseUrlImpl function which eventually caused the test to fail. This PR fixes that.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
