### PR TITLE
Adapt  to the new infra-deployments source code layout

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -21,8 +21,9 @@ spec:
       value: Dockerfile
     - name: infra-deployment-update-script
       value: |
-        sed -i -e 's|\(https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=\)\(.*\)|\1{{ revision }}|' components/spi/kustomization.yaml;
-        awk  -i inplace -v n=1 '/newTag:/ { if (++count == n) sub(/newTag:.*/, "newTag: {{ revision }}")} 1' components/spi/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/service-provider-integration-operator/config/kcp_openshift?ref=\)\(.*\)|\1{{ revision }}|' components/spi/base/kustomization.yaml;
+        awk  -i inplace -v n=1 '/newTag:/ { if (++count == n) sub(/newTag:.*/, "newTag: {{ revision }}")} 1' components/spi/base/kustomization.yaml
+        sed -i -e 's|\(https://raw.githubusercontent.com/redhat-appstudio/service-provider-integration-operator/\)\(.*\)|\1{{ revision }}/hack/vault-init.sh|' hack/preview.sh;
         sed -i -e 's|\(https://github.com/redhat-appstudio/service-provider-integration-operator/config/vault/openshift?ref=\)\(.*\)|\1{{ revision }}|' components/spi/vault/kustomization.yaml
   pipelineRef:
     name: docker-build


### PR DESCRIPTION
### What does this PR do?
 - Replace commit id for project deployment config
 - Replace `redhat-appstudio/service-provider-integration-operator` image  tag
 - Replace commit id for the vault init script.
 - Replace commit id for vault deployment config
 - 
### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
- After migration to kcp infra-deployments source code has a slightly different layout

### How to test this PR?
n/a
