### PR TITLE
Build images with a long commit hash as a tag name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
             quay.io/redhat-appstudio/service-provider-integration-operator
           tags: |
             type=semver,pattern={{version}}
-            type=sha
+            type=sha,format=long
             type=raw,value=next,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
### What does this PR do?
 - Build images with a long commit hash as a tag name

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
- We would like to use long hash tags in our deployments on prod/stage

### How to test this PR?
n/a
