### PR TITLE
Revert to GetBaseUrlImpl method set before the test to not affect other tests

### DIFF
--- a/integration_tests/spiaccessbindingcontroller_test.go
+++ b/integration_tests/spiaccessbindingcontroller_test.go
@@ -654,6 +654,7 @@ var _ = Describe("Status updates", func() {
 					RepoUrl: "invalid://abc./name/repo",
 				},
 			}
+			previousBaseImpl := ITest.HostCredsServiceProvider.GetBaseUrlImpl
 			ITest.HostCredsServiceProvider.GetBaseUrlImpl = func() string {
 				return "invalid://abc."
 			}
@@ -675,7 +676,7 @@ var _ = Describe("Status updates", func() {
 				g.Expect(binding.Status.ErrorReason).To(Equal(api.SPIAccessTokenBindingErrorReasonUnknownServiceProviderType))
 				g.Expect(binding.Status.LinkedAccessTokenName).To(BeEmpty())
 			}).Should(Succeed())
-			ITest.HostCredsServiceProvider.Reset()
+			ITest.HostCredsServiceProvider.GetBaseUrlImpl = previousBaseImpl
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Pavol Baran <pbaran@redhat.com>

### What does this PR do?
After the test, reverts to the GetBaseUrlImpl method that was set before a run of this test. This makes sure that the test does not affect other tests.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
Fixes: https://issues.redhat.com/browse/SVPI-207

The previous solution (#270) did not work because the reset() function set the implementation to nil, however, GetBaseUrlImpl of HostCredsServiceProvider is actually set to a non-nil implementation in the BeforeSuite method (https://github.com/redhat-appstudio/service-provider-integration-operator/blob/main/integration_tests/suite_test.go#L164). As the tests are asynchronous in nature, it means that an error in tests makes the tests pass sometimes (as was the case when testing #270) and sometimes fail.

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
run `make itest` multiple times (you can also try `make test`)