### PR TITLE
Add ability to customize reset() function of TestServiceProvider

### DIFF
--- a/integration_tests/serviceprovider_mock.go
+++ b/integration_tests/serviceprovider_mock.go
@@ -36,7 +36,7 @@ type TestServiceProvider struct {
 	CheckRepositoryAccessImpl func(context.Context, client.Client, *api.SPIAccessCheck) (*api.SPIAccessCheckStatus, error)
 	MapTokenImpl              func(context.Context, *api.SPIAccessTokenBinding, *api.SPIAccessToken, *api.Token) (serviceprovider.AccessTokenMapper, error)
 	ValidateImpl              func(context.Context, serviceprovider.Validated) (serviceprovider.ValidationResult, error)
-	CustomizeReset            func()
+	CustomizeReset            func(provider *TestServiceProvider)
 }
 
 func (t TestServiceProvider) CheckRepositoryAccess(ctx context.Context, cl client.Client, accessCheck *api.SPIAccessCheck) (*api.SPIAccessCheckStatus, error) {
@@ -116,7 +116,7 @@ func (t *TestServiceProvider) Reset() {
 	t.MapTokenImpl = nil
 	t.ValidateImpl = nil
 	if t.CustomizeReset != nil {
-		t.CustomizeReset()
+		t.CustomizeReset(t)
 	}
 }
 

--- a/integration_tests/serviceprovider_mock.go
+++ b/integration_tests/serviceprovider_mock.go
@@ -36,6 +36,7 @@ type TestServiceProvider struct {
 	CheckRepositoryAccessImpl func(context.Context, client.Client, *api.SPIAccessCheck) (*api.SPIAccessCheckStatus, error)
 	MapTokenImpl              func(context.Context, *api.SPIAccessTokenBinding, *api.SPIAccessToken, *api.Token) (serviceprovider.AccessTokenMapper, error)
 	ValidateImpl              func(context.Context, serviceprovider.Validated) (serviceprovider.ValidationResult, error)
+	CustomizeReset            func()
 }
 
 func (t TestServiceProvider) CheckRepositoryAccess(ctx context.Context, cl client.Client, accessCheck *api.SPIAccessCheck) (*api.SPIAccessCheckStatus, error) {
@@ -114,6 +115,9 @@ func (t *TestServiceProvider) Reset() {
 	t.CheckRepositoryAccessImpl = nil
 	t.MapTokenImpl = nil
 	t.ValidateImpl = nil
+	if t.CustomizeReset != nil {
+		t.CustomizeReset()
+	}
 }
 
 // LookupConcreteToken returns a function that can be used as the TestServiceProvider.LookupTokenImpl that just returns

--- a/integration_tests/spiaccessbindingcontroller_test.go
+++ b/integration_tests/spiaccessbindingcontroller_test.go
@@ -654,7 +654,6 @@ var _ = Describe("Status updates", func() {
 					RepoUrl: "invalid://abc./name/repo",
 				},
 			}
-			previousBaseImpl := ITest.HostCredsServiceProvider.GetBaseUrlImpl
 			ITest.HostCredsServiceProvider.GetBaseUrlImpl = func() string {
 				return "invalid://abc."
 			}
@@ -676,7 +675,7 @@ var _ = Describe("Status updates", func() {
 				g.Expect(binding.Status.ErrorReason).To(Equal(api.SPIAccessTokenBindingErrorReasonUnknownServiceProviderType))
 				g.Expect(binding.Status.LinkedAccessTokenName).To(BeEmpty())
 			}).Should(Succeed())
-			ITest.HostCredsServiceProvider.GetBaseUrlImpl = previousBaseImpl
+			ITest.HostCredsServiceProvider.Reset()
 		})
 	})
 

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -156,15 +156,17 @@ var _ = BeforeSuite(func() {
 
 		return "", nil
 	})
-	ITest.HostCredsServiceProvider = TestServiceProvider{
-		GetTypeImpl: func() api.ServiceProviderType {
-			return "HostCredsServiceProvider"
-		},
 
-		GetBaseUrlImpl: func() string {
+	ITest.HostCredsServiceProvider = TestServiceProvider{}
+	ITest.HostCredsServiceProvider.CustomizeReset = func() {
+		ITest.HostCredsServiceProvider.GetTypeImpl = func() api.ServiceProviderType {
+			return "HostCredsServiceProvider"
+		}
+		ITest.HostCredsServiceProvider.GetBaseUrlImpl = func() string {
 			return "not-test-provider://not-baseurl"
-		},
+		}
 	}
+	ITest.HostCredsServiceProvider.Reset()
 
 	ITest.OperatorConfiguration = &opconfig.OperatorConfiguration{
 		SharedConfiguration: config.SharedConfiguration{

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -158,11 +158,11 @@ var _ = BeforeSuite(func() {
 	})
 
 	ITest.HostCredsServiceProvider = TestServiceProvider{}
-	ITest.HostCredsServiceProvider.CustomizeReset = func() {
-		ITest.HostCredsServiceProvider.GetTypeImpl = func() api.ServiceProviderType {
+	ITest.HostCredsServiceProvider.CustomizeReset = func(provider *TestServiceProvider) {
+		provider.GetTypeImpl = func() api.ServiceProviderType {
 			return "HostCredsServiceProvider"
 		}
-		ITest.HostCredsServiceProvider.GetBaseUrlImpl = func() string {
+		provider.GetBaseUrlImpl = func() string {
 			return "not-test-provider://not-baseurl"
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Pavol Baran <pbaran@redhat.com>

### What does this PR do?
Adds the ability to provide a CustomizeReset() function to TestServiceProvider which is executed at the end of Reset() function.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
An improvement upon #280

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
`make itest`