### PR TITLE
update to the new binary name in the deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: manager
         command:
-        - /manager
+        - /operator
         image: quay.io/redhat-appstudio/service-provider-integration-operator:next
         env: []
         envFrom:


### PR DESCRIPTION
### What does this PR do?
`$TITLE` - the deployment yaml for the operator referenced the old binary name, making the deployment enter a crash loop backoff.