### PR TITLE
Start the SPIAccessTokenDataUpdate reconciler in main :-O

### DIFF
--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,7 +30,6 @@ import (
 
 	"github.com/alexflint/go-arg"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceproviders"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	corev1 "k8s.io/api/core/v1"
@@ -96,54 +94,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.SPIAccessTokenReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		TokenStorage: strg,
-		ServiceProviderFactory: serviceprovider.Factory{
-			Configuration:    &cfg,
-			KubernetesClient: mgr.GetClient(),
-			HttpClient:       http.DefaultClient,
-			Initializers:     serviceproviders.KnownInitializers(),
-			TokenStorage:     strg,
-		},
-		Configuration: &cfg,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "SPIAccessToken")
-		os.Exit(1)
-	}
-	if err = (&controllers.SPIAccessTokenBindingReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		TokenStorage: strg,
-		ServiceProviderFactory: serviceprovider.Factory{
-			Configuration:    &cfg,
-			KubernetesClient: mgr.GetClient(),
-			HttpClient:       http.DefaultClient,
-			Initializers:     serviceproviders.KnownInitializers(),
-			TokenStorage:     strg,
-		},
-		Configuration: &cfg,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "SPIAccessTokenBinding")
+	if err = controllers.SetupAllReconcilers(mgr, &cfg, strg, serviceproviders.KnownInitializers()); err != nil {
+		setupLog.Error(err, "failed to set up the controllers")
 		os.Exit(1)
 	}
 
-	if err = (&controllers.SPIAccessCheckReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		ServiceProviderFactory: serviceprovider.Factory{
-			Configuration:    &cfg,
-			KubernetesClient: mgr.GetClient(),
-			HttpClient:       http.DefaultClient,
-			Initializers:     serviceproviders.KnownInitializers(),
-			TokenStorage:     strg,
-		},
-		Configuration: &cfg,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "SPIAccessCheck")
-		os.Exit(1)
-	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/controllers/starter.go
+++ b/controllers/starter.go
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
+	sconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+)
+
+func SetupAllReconcilers(mgr controllerruntime.Manager, cfg *config.OperatorConfiguration, ts tokenstorage.TokenStorage, initializers map[sconfig.ServiceProviderType]serviceprovider.Initializer) error {
+	spf := serviceprovider.Factory{
+		Configuration:    cfg,
+		KubernetesClient: mgr.GetClient(),
+		HttpClient:       http.DefaultClient,
+		Initializers:     initializers,
+		TokenStorage:     ts,
+	}
+
+	var err error
+
+	if err = (&SPIAccessTokenReconciler{
+		Client:                 mgr.GetClient(),
+		Scheme:                 mgr.GetScheme(),
+		TokenStorage:           ts,
+		ServiceProviderFactory: spf,
+		Configuration:          cfg,
+	}).SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	if err = (&SPIAccessTokenBindingReconciler{
+		Client:                 mgr.GetClient(),
+		Scheme:                 mgr.GetScheme(),
+		TokenStorage:           ts,
+		ServiceProviderFactory: spf,
+		Configuration:          cfg,
+	}).SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	if err = (&SPIAccessTokenDataUpdateReconciler{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	if err = (&SPIAccessCheckReconciler{
+		Client:                 mgr.GetClient(),
+		Scheme:                 mgr.GetScheme(),
+		ServiceProviderFactory: spf,
+		Configuration:          cfg,
+	}).SetupWithManager(mgr); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -205,69 +205,31 @@ var _ = BeforeSuite(func() {
 
 	Expect(ITest.TokenStorage.Initialize(ctx)).To(Succeed())
 
-	factory := serviceprovider.Factory{
-		Configuration:    ITest.OperatorConfiguration,
-		KubernetesClient: mgr.GetClient(),
-		HttpClient:       http.DefaultClient,
-		Initializers: map[config.ServiceProviderType]serviceprovider.Initializer{
-			"TestServiceProvider": {
-				Probe: serviceprovider.ProbeFunc(func(cl *http.Client, baseUrl string) (string, error) {
-					return ITest.TestServiceProviderProbe.Examine(cl, baseUrl)
-				}),
-				Constructor: serviceprovider.ConstructorFunc(func(f *serviceprovider.Factory, _ string) (serviceprovider.ServiceProvider, error) {
-					return ITest.TestServiceProvider, nil
-				}),
-			},
-			"HostCredentials": {
-				Probe: serviceprovider.ProbeFunc(func(cl *http.Client, baseUrl string) (string, error) {
-					return ITest.TestServiceProviderProbe.Examine(cl, baseUrl)
-				}),
-				Constructor: serviceprovider.ConstructorFunc(func(f *serviceprovider.Factory, _ string) (serviceprovider.ServiceProvider, error) {
-					return ITest.HostCredsServiceProvider, nil
-				}),
-			},
-		},
-		TokenStorage: strg,
-	}
-
 	// the controllers themselves do not need the notifying token storage because they operate in the cluster
 	// the notifying token storage is only needed if changes are only made to the storage and the cluster needs to be
 	// notified about it. This only happens in OAuth service or in tests. So the test code is using notifying token
 	// storage so that the controllers can react to the changes made to the token storage by the testsuite but the
 	// controllers themselves use the "raw" token storage because they only write to the storage based on the conditions
 	// in the cluster.
-	err = (&controllers.SPIAccessTokenReconciler{
-		Client:                 mgr.GetClient(),
-		Scheme:                 mgr.GetScheme(),
-		TokenStorage:           strg,
-		Configuration:          ITest.OperatorConfiguration,
-		ServiceProviderFactory: factory,
-	}).SetupWithManager(mgr)
+	err = controllers.SetupAllReconcilers(mgr, ITest.OperatorConfiguration, strg, map[config.ServiceProviderType]serviceprovider.Initializer{
+		"TestServiceProvider": {
+			Probe: serviceprovider.ProbeFunc(func(cl *http.Client, baseUrl string) (string, error) {
+				return ITest.TestServiceProviderProbe.Examine(cl, baseUrl)
+			}),
+			Constructor: serviceprovider.ConstructorFunc(func(f *serviceprovider.Factory, _ string) (serviceprovider.ServiceProvider, error) {
+				return ITest.TestServiceProvider, nil
+			}),
+		},
+		"HostCredentials": {
+			Probe: serviceprovider.ProbeFunc(func(cl *http.Client, baseUrl string) (string, error) {
+				return ITest.TestServiceProviderProbe.Examine(cl, baseUrl)
+			}),
+			Constructor: serviceprovider.ConstructorFunc(func(f *serviceprovider.Factory, _ string) (serviceprovider.ServiceProvider, error) {
+				return ITest.HostCredsServiceProvider, nil
+			}),
+		},
+	})
 	Expect(err).NotTo(HaveOccurred())
-
-	err = (&controllers.SPIAccessTokenBindingReconciler{
-		Client:                 mgr.GetClient(),
-		Scheme:                 mgr.GetScheme(),
-		TokenStorage:           strg,
-		Configuration:          ITest.OperatorConfiguration,
-		ServiceProviderFactory: factory,
-	}).SetupWithManager(mgr)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = (&controllers.SPIAccessTokenDataUpdateReconciler{
-		Client: mgr.GetClient(),
-	}).SetupWithManager(mgr)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = (&controllers.SPIAccessCheckReconciler{
-		Client:                 mgr.GetClient(),
-		Scheme:                 mgr.GetScheme(),
-		ServiceProviderFactory: factory,
-		Configuration:          ITest.OperatorConfiguration,
-	}).SetupWithManager(mgr)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:webhook
 
 	go func() {
 		err = mgr.Start(ctx)


### PR DESCRIPTION
### What does this PR do?
Shockingly, I've found that we didn't ever start the reconciler for the SPIAccessTokenDataUpdate objects. Things worked because other reconcilers also listen to events on those objects, but the SPIAccessTokenDataUpdate objects were never cleared in the cluster. Note that this worked correctly in the integration tests, because there, the reconciler IS started.

As a consequence, this also solves SVPI-104, because the metrics of SPIAccessTokenUpdate reconciliation durations (which equate to its lifetime in this case) are published by the controller runtime itself.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-104

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
