### PR TITLE
some makefile improvements to better suite 2 binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG baseimage=registry.access.redhat.com/ubi8/ubi-minimal:8.6-941
+
 # Build the manager binary
 FROM golang:1.18 as builder
 
@@ -22,7 +24,7 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/ -a ./cmd/...
 
 # Compose the final image of spi-oauth service
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 as spi-oauth
+FROM $baseimage as spi-oauth
 
 # Install the 'shadow-utils' which contains `adduser` and `groupadd` binaries
 RUN microdnf install shadow-utils \
@@ -46,7 +48,7 @@ ENTRYPOINT ["/spi-oauth"]
 
 # Compose the final image of spi-operator.
 # !!! This must be last one, because we want simple `docker build .` to build the operator image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-941 as spi-operator
+FROM $baseimage as spi-operator
 
 # Install the 'shadow-utils' which contains `adduser` and `groupadd` binaries
 RUN microdnf install shadow-utils \

--- a/README.md
+++ b/README.md
@@ -21,19 +21,20 @@ To test the code:
 make test
 ```
 
-To build the docker image of the operator one can run:
+To build the docker images of the operator and oauth service one can run:
 
 ```
 make docker-build
 ```
 
-This will make a docker image called `controller:latest` which might or might not be what you want. To override the name of the image build, specify it in the `SPIO_IMG` environment variable, e.g.:
+This will make a docker images called `quay.io/redhat-appstudio/service-provider-integration-operator:next` and `quay.io/redhat-appstudio/service-provider-integration-oauth:next` which might or might not be what you want.
+To override the name of the image build, specify it in the `SPI_IMG_BASE` and/or `TAG_NAME` environment variable (see [Makefile](Makefile) for more granular options), e.g.:
 
 ```
-SPIO_IMG=quay.io/acme/spio:42 make docker-build
+SPI_IMG_BASE=quay.io/acme TAG_NAME=bugfix make docker-build
 ```
 
-To push the image to an image repository one can use:
+To push the images to an image repository one can use:
 
 ```
 make docker-push
@@ -41,7 +42,7 @@ make docker-push
 
 The image being pushed can again be modified using the environment variable:
 ```
-SPIO_IMG=quay.io/acme/spio:42 make docker-push
+SPI_IMG_BASE=quay.io/acme TAG_NAME=bugfix make docker-push
 ```
 
 Before you push a PR to the repository, it is recommended to run an overall validity check of the codebase. This will


### PR DESCRIPTION
### What does this PR do?
 - option to set `SPI_IMG_BASE` for `make docker-build`
 - targets to build just operator or oauth image
 - targets to push just operator or oauth image
 - baseimage in dockerfile as variable to easier keep in sync and update
 - option to run oauth serviec

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-225

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
test makefile targets