### PR TITLE
fix way how we construct context with kcp

### DIFF
--- a/controllers/spiaccesscheck_controller.go
+++ b/controllers/spiaccesscheck_controller.go
@@ -51,7 +51,7 @@ type SPIAccessCheckReconciler struct {
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=spiaccesschecks/finalizers,verbs=update
 
 func (r *SPIAccessCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	ctx = infrastructure.InitKcpControllerContext(ctx, req)
+	ctx = infrastructure.InitKcpContext(ctx, req.ClusterName)
 
 	lg := log.FromContext(ctx)
 	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessCheck")

--- a/controllers/spiaccesstoken_controller.go
+++ b/controllers/spiaccesstoken_controller.go
@@ -131,7 +131,7 @@ func requestsForTokenInObjectNamespace(object client.Object, tokenNameExtractor 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *SPIAccessTokenReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	ctx = infrastructure.InitKcpControllerContext(ctx, req)
+	ctx = infrastructure.InitKcpContext(ctx, req.ClusterName)
 
 	lg := log.FromContext(ctx)
 	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessToken")

--- a/controllers/spiaccesstoken_controller_test.go
+++ b/controllers/spiaccesstoken_controller_test.go
@@ -18,7 +18,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/infrastructure"
+
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 	sconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
@@ -43,7 +44,7 @@ func TestCreateUploadUrl(t *testing.T) {
 	}
 
 	t.Run("kcp-env", func(t *testing.T) {
-		ctx := logicalcluster.WithCluster(context.TODO(), logicalcluster.New("workspace"))
+		ctx := infrastructure.InitKcpContext(context.TODO(), "workspace")
 		url := r.createUploadUrl(ctx, at)
 		assert.Contains(t, url, "blabol")
 		assert.Contains(t, url, "workspace")

--- a/controllers/spiaccesstokendataupdate_controller.go
+++ b/controllers/spiaccesstokendataupdate_controller.go
@@ -67,7 +67,7 @@ func (r *SPIAccessTokenDataUpdateReconciler) SetupWithManager(mgr ctrl.Manager) 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *SPIAccessTokenDataUpdateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	ctx = infrastructure.InitKcpControllerContext(ctx, req)
+	ctx = infrastructure.InitKcpContext(ctx, req.ClusterName)
 
 	lg := log.FromContext(ctx)
 	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessTokenData")

--- a/controllers/spifilecontentrequest_controller.go
+++ b/controllers/spifilecontentrequest_controller.go
@@ -60,10 +60,7 @@ func (r *SPIFileContentRequestReconciler) SetupWithManager(mgr ctrl.Manager) err
 		For(&api.SPIFileContentRequest{}).
 		Watches(&source.Kind{Type: &api.SPIAccessTokenBinding{}}, handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
 			kcpWorkspace := logicalcluster.From(o)
-			ctx := context.TODO()
-			if !kcpWorkspace.Empty() {
-				ctx = logicalcluster.WithCluster(ctx, kcpWorkspace)
-			}
+			ctx := infrastructure.InitKcpContext(context.Background(), kcpWorkspace.String())
 
 			fileRequests := &api.SPIFileContentRequestList{}
 			if err := r.K8sClient.List(ctx, fileRequests, client.InNamespace(o.GetNamespace())); err != nil {
@@ -93,7 +90,7 @@ func (r *SPIFileContentRequestReconciler) SetupWithManager(mgr ctrl.Manager) err
 }
 
 func (r *SPIFileContentRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	ctx = infrastructure.InitKcpControllerContext(ctx, req)
+	ctx = infrastructure.InitKcpContext(ctx, req.ClusterName)
 	lg := log.FromContext(ctx)
 
 	request := api.SPIFileContentRequest{}

--- a/oauth/client_factory.go
+++ b/oauth/client_factory.go
@@ -81,7 +81,7 @@ type kcpWorkspaceRoundTripper struct {
 }
 
 func (w kcpWorkspaceRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
-	if clusterName, hasClusterName := logicalcluster.ClusterFromContext(request.Context()); hasClusterName {
+	if clusterName, hasClusterName := logicalcluster.ClusterFromContext(request.Context()); hasClusterName && !clusterName.Empty() {
 		request.URL.Path = path.Join(clusterName.Path(), request.URL.Path)
 	}
 	response, err := w.next.RoundTrip(request)

--- a/oauth/client_factory.go
+++ b/oauth/client_factory.go
@@ -73,7 +73,7 @@ func CreateClient(cfg *rest.Config, options client.Options) (AuthenticatingClien
 //
 // client usage then looks like this:
 // ...
-// ctx = logicalcluster.WithCluster(ctx, logicalcluster.New("kcp-workspace"))
+// ctx = infrastructure.InitKcpContext(ctx, "kcp-workspace")
 // err := client.Get(ctx, client.ObjectKey{Name: "object-name", Namespace: "object-namespace"}, object)
 // ...
 type kcpWorkspaceRoundTripper struct {

--- a/oauth/client_factory_test.go
+++ b/oauth/client_factory_test.go
@@ -14,7 +14,12 @@
 package oauth
 
 import (
+	"context"
+	"net/http"
+	"net/url"
 	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v2"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -31,4 +36,42 @@ func TestCreateClient(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cl.Scheme().AllKnownTypes())
+}
+
+func TestKcpRoundtripper(t *testing.T) {
+	roundTripper := kcpWorkspaceRoundTripper{
+		next: fakeRoundTrip(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{Request: r}, nil
+		}),
+	}
+
+	inputPath := "/some/path"
+
+	t.Run("no workspace does not update path", func(t *testing.T) {
+		req := &http.Request{
+			URL: &url.URL{Path: inputPath},
+		}
+		req = req.WithContext(context.TODO())
+		response, _ := roundTripper.RoundTrip(req)
+		assert.Equal(t, inputPath, response.Request.URL.Path)
+	})
+
+	t.Run("empty workspace does not update path", func(t *testing.T) {
+		req := &http.Request{
+			URL: &url.URL{Path: inputPath},
+		}
+		req = req.WithContext(logicalcluster.WithCluster(context.TODO(), logicalcluster.New("")))
+		response, _ := roundTripper.RoundTrip(req)
+		assert.Equal(t, inputPath, response.Request.URL.Path)
+	})
+
+	t.Run("some workspace updates path", func(t *testing.T) {
+		req := &http.Request{
+			URL: &url.URL{Path: inputPath},
+		}
+		req = req.WithContext(logicalcluster.WithCluster(context.TODO(), logicalcluster.New("some-kcp-workspace")))
+		response, _ := roundTripper.RoundTrip(req)
+		assert.NotEqual(t, inputPath, response.Request.URL.Path)
+		assert.Contains(t, response.Request.URL.Path, "some-kcp-workspace")
+	})
 }

--- a/oauth/common.go
+++ b/oauth/common.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/infrastructure"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 
@@ -149,7 +149,7 @@ func (c commonController) Callback(ctx context.Context, w http.ResponseWriter, r
 		LogErrorAndWriteResponse(ctx, w, http.StatusBadRequest, "error in Service Provider token exchange", err)
 		return
 	}
-	ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(exchange.TokenKcpWorkspace))
+	ctx = infrastructure.InitKcpContext(ctx, exchange.TokenKcpWorkspace)
 
 	if exchange.result == oauthFinishK8sAuthRequired {
 		LogErrorAndWriteResponse(ctx, w, http.StatusUnauthorized, "could not authenticate to Kubernetes", err)
@@ -249,7 +249,7 @@ func (c *commonController) checkIdentityHasAccess(token string, req *http.Reques
 	}
 
 	ctx := WithAuthIntoContext(token, req.Context())
-	ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(state.TokenKcpWorkspace))
+	ctx = infrastructure.InitKcpContext(ctx, state.TokenKcpWorkspace)
 
 	if err := c.K8sClient.Create(ctx, &review); err != nil {
 		return false, fmt.Errorf("failed to create SelfSubjectAccessReview: %w", err)

--- a/oauth/handlers.go
+++ b/oauth/handlers.go
@@ -18,12 +18,12 @@ import (
 	"html/template"
 	"net/http"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/infrastructure"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/kcp-dev/logicalcluster/v2"
 
 	"github.com/go-jose/go-jose/v3/json"
 	"github.com/gorilla/handlers"
@@ -91,7 +91,7 @@ func HandleUpload(uploader TokenUploader) func(http.ResponseWriter, *http.Reques
 		tokenObjectName := vars["name"]
 		tokenObjectNamespace := vars["namespace"]
 		if tokenObjectKcpWorkspace, hasKcpWorkspace := vars["kcpWorkspace"]; hasKcpWorkspace {
-			ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(tokenObjectKcpWorkspace))
+			ctx = infrastructure.InitKcpContext(ctx, tokenObjectKcpWorkspace)
 		}
 
 		if len(tokenObjectName) < 1 || len(tokenObjectNamespace) < 1 {

--- a/pkg/infrastructure/kcp.go
+++ b/pkg/infrastructure/kcp.go
@@ -117,11 +117,11 @@ func restConfigForAPIExport(ctx context.Context, cfg *rest.Config, apiExportName
 	return cfg, nil
 }
 
-func InitKcpControllerContext(ctx context.Context, req ctrl.Request) context.Context {
+func InitKcpContext(ctx context.Context, kcpWorkspace string) context.Context {
 	// if we're running on kcp, we need to include workspace name in context and logs
-	if req.ClusterName != "" {
-		ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(req.ClusterName))
-		ctx = log.IntoContext(ctx, log.FromContext(ctx, "clusterName", req.ClusterName))
+	if kcpWorkspace != "" {
+		ctx = logicalcluster.WithCluster(ctx, logicalcluster.New(kcpWorkspace))
+		ctx = log.IntoContext(ctx, log.FromContext(ctx, "clusterName", kcpWorkspace))
 	}
 
 	return ctx

--- a/pkg/infrastructure/kcp_test.go
+++ b/pkg/infrastructure/kcp_test.go
@@ -21,10 +21,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/kcp-dev/logicalcluster/v2"
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -95,16 +93,14 @@ func TestRestApiConfig(t *testing.T) {
 
 func TestInitKcpControllerContext(t *testing.T) {
 	t.Run("no workspace", func(t *testing.T) {
-		ctx := InitKcpControllerContext(context.TODO(), ctrl.Request{})
+		ctx := InitKcpContext(context.TODO(), "")
 
 		_, hasClusterName := logicalcluster.ClusterFromContext(ctx)
 		assert.False(t, hasClusterName)
 	})
 
 	t.Run("kcp workspace", func(t *testing.T) {
-		ctx := InitKcpControllerContext(context.TODO(), ctrl.Request{
-			ClusterName: "workspace",
-		})
+		ctx := InitKcpContext(context.TODO(), "workspace")
 
 		clusterName, hasClusterName := logicalcluster.ClusterFromContext(ctx)
 		assert.True(t, hasClusterName)

--- a/pkg/spi-shared/tokenstorage/tokenstorage_vault_test.go
+++ b/pkg/spi-shared/tokenstorage/tokenstorage_vault_test.go
@@ -20,10 +20,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/infrastructure"
+
 	"github.com/prometheus/client_golang/prometheus"
 	prometheusTest "github.com/prometheus/client_golang/prometheus/testutil"
-
-	"github.com/kcp-dev/logicalcluster/v2"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 
@@ -79,11 +79,11 @@ func TestStorage(t *testing.T) {
 	})
 
 	t.Run("kcp", func(t *testing.T) {
-		test(logicalcluster.WithCluster(context.Background(), logicalcluster.New("test_workspace")))
+		test(infrastructure.InitKcpContext(context.Background(), "test_workspace"))
 	})
 
 	t.Run("token accessible only in it's workspace", func(t *testing.T) {
-		workspaceCtx := logicalcluster.WithCluster(context.Background(), logicalcluster.New("test_workspace"))
+		workspaceCtx := infrastructure.InitKcpContext(context.Background(), "test_workspace")
 
 		err := storage.Store(workspaceCtx, testSpiAccessToken, testToken)
 		assert.NoError(t, err)
@@ -92,7 +92,7 @@ func TestStorage(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, gettedToken)
 
-		gettedToken, err = storage.Get(logicalcluster.WithCluster(context.Background(), logicalcluster.New("another_workspace")), testSpiAccessToken)
+		gettedToken, err = storage.Get(infrastructure.InitKcpContext(context.Background(), "another_workspace"), testSpiAccessToken)
 		assert.NoError(t, err)
 		assert.Nil(t, gettedToken)
 


### PR DESCRIPTION
### What does this PR do?
Change how we construct context with kcp workspaces. This did not work fully in case kcp workspace was empty.

The issue was in our kcp roundtripper, that updates request url path. We updated the path even when kcp workspace was empty string. It worked only for cases where we did not has any clustername value in the context.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-247

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

images:
 - `quay.io/mvala/service-provider-integration-operator:svpi247-oauthfix`
 - `quay.io/mvala/service-provider-integration-oauth:svpi247-oauthfix`

 - get token using oauth link on single-cluster and on KCP