### PR TITLE
add GitLab as supported service provider

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.50.0
+          version: v1.50.1
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/README.md
+++ b/README.md
@@ -328,10 +328,15 @@ kubectl get secret token-secret -o yaml
 
 The currently supported list of providers and token kinds is following:
 
-### Github
+### GitHub
 
  - OAuth token via user authentication flow
  - Personal access token via manual upload
+
+### GitLab
+
+- OAuth token via user authentication flow
+- Personal access token via manual upload
 
 ### Quay
 

--- a/api/v1beta1/spiaccesstoken_types.go
+++ b/api/v1beta1/spiaccesstoken_types.go
@@ -126,6 +126,7 @@ const (
 	PermissionAreaRepositoryMetadata PermissionArea = "repositoryMetadata"
 	PermissionAreaWebhooks           PermissionArea = "webhooks"
 	PermissionAreaUser               PermissionArea = "user"
+	PermissionAreaRegistry           PermissionArea = "registry"
 )
 
 // SPIAccessTokenStatus defines the observed state of SPIAccessToken

--- a/api/v1beta1/spiaccesstoken_types.go
+++ b/api/v1beta1/spiaccesstoken_types.go
@@ -82,6 +82,7 @@ type ServiceProviderType string
 const (
 	ServiceProviderTypeGitHub          ServiceProviderType = "GitHub"
 	ServiceProviderTypeQuay            ServiceProviderType = "Quay"
+	ServiceProviderTypeGitLab          ServiceProviderType = "GitLab"
 	ServiceProviderTypeHostCredentials ServiceProviderType = "HostCredentials"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-hclog v1.3.1
-	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/vault v1.12.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.13.3
 	github.com/hashicorp/vault/api v1.8.1
@@ -146,6 +145,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.5 // indirect
 	github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-hclog v1.3.1
+	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/vault v1.12.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.13.3
 	github.com/hashicorp/vault/api v1.8.1
@@ -145,7 +146,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.5 // indirect
 	github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-hclog v1.3.1
+	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/vault v1.12.0
 	github.com/hashicorp/vault-plugin-secrets-kv v0.13.3
 	github.com/hashicorp/vault/api v1.8.1
@@ -29,8 +30,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.1
 	github.com/stretchr/testify v1.8.1
+	github.com/xanzy/go-gitlab v0.73.1
 	go.uber.org/zap v1.23.0
-	golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401
+	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.3
 	k8s.io/apiextensions-apiserver v0.24.3
@@ -44,8 +46,8 @@ require (
 replace sigs.k8s.io/controller-runtime => github.com/kcp-dev/controller-runtime v0.12.2-0.20220902130817-824b15a11b18
 
 require (
-	cloud.google.com/go v0.100.2 // indirect
-	cloud.google.com/go/compute v1.6.1 // indirect
+	cloud.google.com/go v0.102.0 // indirect
+	cloud.google.com/go/compute v1.7.0 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
 	cloud.google.com/go/kms v1.4.0 // indirect
 	cloud.google.com/go/monitoring v1.2.0 // indirect
@@ -122,6 +124,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gophercloud/gophercloud v0.1.0 // indirect
 	github.com/hashicorp/consul/sdk v0.11.0 // indirect
@@ -143,7 +146,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.5 // indirect
 	github.com/hashicorp/go-raftchunking v0.6.3-0.20191002164813-7e9e8525653a // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 // indirect
@@ -235,11 +237,11 @@ require (
 	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
-	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
+	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
-	google.golang.org/api v0.83.0 // indirect
+	google.golang.org/api v0.84.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220602131408-e326c6e8e9c8 // indirect
+	google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90 // indirect
 	google.golang.org/grpc v1.47.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,9 @@ cloud.google.com/go v0.94.1/go.mod h1:qAlAugsXlC+JWO+Bke5vCtc9ONxjQT3drlTTnAplMW
 cloud.google.com/go v0.97.0/go.mod h1:GF7l59pYBVlXQIBLx3a761cZ41F9bBH3JUlihCt2Udc=
 cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2ZA=
 cloud.google.com/go v0.100.1/go.mod h1:fs4QogzfH5n2pBXBP9vRiU+eCny7lD2vmFZy79Iuw1U=
-cloud.google.com/go v0.100.2 h1:t9Iw5QH5v4XtlEQaCtUY7x6sCABps8sW0acw7e2WQ6Y=
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
+cloud.google.com/go v0.102.0 h1:DAq3r8y4mDgyB/ZPJ9v/5VJNqjgJAxTn6ZYLlUywOu8=
+cloud.google.com/go v0.102.0/go.mod h1:oWcCzKlqJ5zgHQt9YsaeTY9KzIvjyy0ArmiBUgpQ+nc=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -40,8 +41,9 @@ cloud.google.com/go/compute v0.1.0/go.mod h1:GAesmwr110a34z04OlxYkATPBEfVhkymfTB
 cloud.google.com/go/compute v1.3.0/go.mod h1:cCZiE1NHEtai4wiufUhW8I8S1JKkAnhnQJWM7YD99wM=
 cloud.google.com/go/compute v1.5.0/go.mod h1:9SMHyhJlzhlkJqrPAc839t2BZFTSk6Jdj6mkzQJeu0M=
 cloud.google.com/go/compute v1.6.0/go.mod h1:T29tfhtVbq1wvAPo0E3+7vhgmkOYeXjhFvz/FMzPu0s=
-cloud.google.com/go/compute v1.6.1 h1:2sMmt8prCn7DPaG4Pmh0N3Inmc8cT8ae5k1M6VJ9Wqc=
 cloud.google.com/go/compute v1.6.1/go.mod h1:g85FgpzFvNULZ+S8AYq87axRKuf2Kh7deLqV/jJ3thU=
+cloud.google.com/go/compute v1.7.0 h1:v/k9Eueb8aAJ0vZuxKMrgm6kPhCLZU9HxFU+AFDs9Uk=
+cloud.google.com/go/compute v1.7.0/go.mod h1:435lt8av5oL9P3fv1OEzSbSUe+ybHXGMPQHHZWZxy9U=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
@@ -61,6 +63,7 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
 code.cloudfoundry.org/gofileutils v0.0.0-20170111115228-4d0c80011a0f h1:UrKzEwTgeiff9vxdrfdqxibzpWjxLnuXDI5m6z3GJAk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-pipeline-go v0.2.3 h1:7U9HBg1JFK3jHl5qmo4CTZKFTVgMwdFHMVtCdfBE21U=
@@ -624,6 +627,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa h1:7MYGT2XEMam7Mtzv1yDUYXANedWvwk3HKkR3MyGowy8=
+github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
@@ -635,6 +640,7 @@ github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -1250,6 +1256,8 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vmware/govmomi v0.18.0 h1:f7QxSmP7meCtoAmiKZogvVbLInT+CZx6Px6K5rYsJZo=
 github.com/vmware/govmomi v0.18.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
+github.com/xanzy/go-gitlab v0.73.1 h1:UMagqUZLJdjss1SovIC+kJCH4k2AZWXl58gJd38Y/hI=
+github.com/xanzy/go-gitlab v0.73.1/go.mod h1:d/a0vswScO7Agg1CZNz15Ic6SSvBG9vfw8egL99t4kA=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2 h1:akYIkZ28e6A96dkWNJQu3nmCzH3YfwMPQExUYDaRv7w=
@@ -1479,8 +1487,9 @@ golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
-golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401 h1:zwrSfklXn0gxyLRX/aR+q6cgHbV/ItVyzbPlbA+dkAw=
-golang.org/x/oauth2 v0.0.0-20220524215830-622c5d57e401/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
+golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c h1:q3gFqPqH7NVofKo3c3yETAP//pPI+G5mvB7qqj1Y5kY=
+golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1595,6 +1604,7 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1620,8 +1630,8 @@ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220210224613-90d013bbcef8/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20220411224347-583f2d630306 h1:+gHMid33q6pen7kv9xvT+JRinntgeXO2AeZVd0AWD3w=
-golang.org/x/time v0.0.0-20220411224347-583f2d630306/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9 h1:ftMN5LMiBFjbzleLqtoBZk7KdJwhuybIU+FckUHgoyQ=
+golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -1698,8 +1708,9 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df h1:5Pf6pFKu98ODmgnpvkJ3kFUOQGGLIzLIkbzUHp47618=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=
+golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
@@ -1740,8 +1751,9 @@ google.golang.org/api v0.71.0/go.mod h1:4PyU6e6JogV1f9eA4voyrTY2batOLdgZ5qZ5HOCc
 google.golang.org/api v0.74.0/go.mod h1:ZpfMZOVRMywNyvJFeqL9HRWBgAuRfSjJFpe9QtRRyDs=
 google.golang.org/api v0.75.0/go.mod h1:pU9QmyHLnzlpar1Mjt4IbapUCy8J+6HD6GeELN69ljA=
 google.golang.org/api v0.78.0/go.mod h1:1Sg78yoMLOhlQTeF+ARBoytAcH1NNyyl390YMy6rKmw=
-google.golang.org/api v0.83.0 h1:pMvST+6v+46Gabac4zlJlalxZjCeRcepwg2EdBU+nCc=
-google.golang.org/api v0.83.0/go.mod h1:CNywQoj/AfhTw26ZWAa6LwOv+6WFxHmeLPZq2uncLZk=
+google.golang.org/api v0.80.0/go.mod h1:xY3nI94gbvBrE0J6NHXhxOmW97HG7Khjkku6AFB3Hyg=
+google.golang.org/api v0.84.0 h1:NMB9J4cCxs9xEm+1Z9QiO3eFvn7EnQj3Eo3hN6ugVlg=
+google.golang.org/api v0.84.0/go.mod h1:NTsGnUFJMYROtiquksZHBWtHfeMC7iYthki7Eq3pa8o=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1794,6 +1806,7 @@ google.golang.org/genproto v0.0.0-20210222152913-aa3ee6e6a81c/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210329143202-679c6ae281ee/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
@@ -1829,8 +1842,11 @@ google.golang.org/genproto v0.0.0-20220414192740-2d67ff6cf2b4/go.mod h1:8w6bsBMX
 google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
-google.golang.org/genproto v0.0.0-20220602131408-e326c6e8e9c8 h1:qRu95HZ148xXw+XeZ3dvqe85PxH4X8+jIo0iRPKcEnM=
-google.golang.org/genproto v0.0.0-20220602131408-e326c6e8e9c8/go.mod h1:yKyY4AMRwFiC8yMMNaMi+RkCnjZJt9LoWuvhXjMs+To=
+google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90 h1:4SPz2GL2CXJt28MTF8V6Ap/9ZiVbQlJeGSd9qtA7DLs=
+google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/oauth/controller.go
+++ b/oauth/controller.go
@@ -67,9 +67,13 @@ func FromConfiguration(fullConfig OAuthServiceConfiguration, spConfig config.Ser
 	case config.ServiceProviderTypeQuay:
 		endpoint = quayEndpoint
 	case config.ServiceProviderTypeGitLab:
-		endpoint = oauth2.Endpoint{
-			AuthURL:  spConfig.ServiceProviderBaseUrl + "/oauth/authorize",
-			TokenURL: spConfig.ServiceProviderBaseUrl + "/oauth/token",
+		if spConfig.ServiceProviderBaseUrl == "" {
+			endpoint = gitlabEndpoint
+		} else {
+			endpoint = oauth2.Endpoint{
+				AuthURL:  spConfig.ServiceProviderBaseUrl + "/oauth/authorize",
+				TokenURL: spConfig.ServiceProviderBaseUrl + "/oauth/token",
+			}
 		}
 	default:
 		return nil, notImplementedError

--- a/oauth/controller.go
+++ b/oauth/controller.go
@@ -66,6 +66,11 @@ func FromConfiguration(fullConfig OAuthServiceConfiguration, spConfig config.Ser
 		endpoint = github.Endpoint
 	case config.ServiceProviderTypeQuay:
 		endpoint = quayEndpoint
+	case config.ServiceProviderTypeGitLab:
+		endpoint = oauth2.Endpoint{
+			AuthURL:  spConfig.ServiceProviderBaseUrl + "/oauth/authorize",
+			TokenURL: spConfig.ServiceProviderBaseUrl + "/oauth/token",
+		}
 	default:
 		return nil, notImplementedError
 	}

--- a/oauth/gitlab.go
+++ b/oauth/gitlab.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"golang.org/x/oauth2"
+)
+
+// gitlabEndpoint is the OAuth endpoints specification of SAAS GitLab instance.
+var gitlabEndpoint = oauth2.Endpoint{
+	AuthURL:  "https://gitlab.com/oauth/authorize",
+	TokenURL: "https://gitlab.com/oauth/token",
+}

--- a/pkg/serviceprovider/gitlab/gitlab.go
+++ b/pkg/serviceprovider/gitlab/gitlab.go
@@ -2,9 +2,13 @@ package gitlab
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/xanzy/go-gitlab"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
@@ -14,6 +18,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var unsupportedScopeError = errors.New("unsupported scope for GitLab")
+var unsupportedAreaError = errors.New("unsupported permission area for GitLab")
+var userWritePermissionsNotSupportedError = errors.New("user write permissions are not supported by GitLab")
+
+// Temp
+var notGitlabUrlError = errors.New("not a gitlab repository url")
+
 var _ serviceprovider.ServiceProvider = (*Gitlab)(nil)
 
 type Gitlab struct {
@@ -22,22 +33,31 @@ type Gitlab struct {
 	metadataProvider *metadataProvider
 	httpClient       rest.HTTPClient
 	tokenStorage     tokenstorage.TokenStorage
+	glClientBuilder  gitlabClientBuilder
 	baseUrl          string
 }
 
 var _ serviceprovider.ConstructorFunc = newGitlab
 
-func newGitlab(factory *serviceprovider.Factory, baseUrl string) (serviceprovider.ServiceProvider, error) {
+var Initializer = serviceprovider.Initializer{
+	Probe:                        gitlabProbe{},
+	Constructor:                  serviceprovider.ConstructorFunc(newGitlab),
+	SupportsManualUploadOnlyMode: true,
+}
 
-	// in Quay, we invalidate the individual cached repository records, because we're filling up the cache repo-by-repo
-	// therefore the metadata as a whole never gets refreshed.
+func newGitlab(factory *serviceprovider.Factory, baseUrl string) (serviceprovider.ServiceProvider, error) {
 	cache := serviceprovider.NewMetadataCache(factory.KubernetesClient, &serviceprovider.NeverMetadataExpirationPolicy{})
-	mp := &metadataProvider{
-		tokenStorage:     factory.TokenStorage,
-		httpClient:       factory.HttpClient,
-		kubernetesClient: factory.KubernetesClient,
-		ttl:              factory.Configuration.TokenLookupCacheTtl,
+	glClientBuilder := gitlabClientBuilder{
+		httpClient:   factory.HttpClient,
+		tokenStorage: factory.TokenStorage,
 	}
+	mp := &metadataProvider{
+		tokenStorage:    factory.TokenStorage,
+		httpClient:      factory.HttpClient,
+		glClientBuilder: glClientBuilder,
+		baseUrl:         baseUrl,
+	}
+
 	return &Gitlab{
 		Configuration: factory.Configuration,
 		lookup: serviceprovider.GenericLookup{
@@ -50,6 +70,7 @@ func newGitlab(factory *serviceprovider.Factory, baseUrl string) (serviceprovide
 		tokenStorage:     factory.TokenStorage,
 		metadataProvider: mp,
 		httpClient:       factory.HttpClient,
+		glClientBuilder:  glClientBuilder,
 		baseUrl:          baseUrl,
 	}, nil
 }
@@ -75,12 +96,30 @@ func (g Gitlab) PersistMetadata(ctx context.Context, _ client.Client, token *api
 }
 
 func (g Gitlab) GetBaseUrl() string {
-	return g.BaseUrl
+	return g.baseUrl
 }
 
-func (g Gitlab) OAuthScopesFor(permissions *api.Permissions) []string {
-	//TODO implement me
-	panic("implement me")
+func (g *Gitlab) OAuthScopesFor(permissions *api.Permissions) []string {
+	return serviceprovider.GetAllScopes(translateToGitlabScopes, permissions)
+}
+
+func translateToGitlabScopes(permission api.Permission) []string {
+	switch permission.Area {
+	case api.PermissionAreaRepository, api.PermissionAreaRepositoryMetadata:
+		if permission.Type.IsWrite() {
+			return []string{string(ScopeWriteRepository)}
+		}
+		return []string{string(ScopeReadRepository)}
+	case api.PermissionAreaRegistry:
+		if permission.Type.IsWrite() {
+			return []string{string(ScopeWriteRegistry)}
+		}
+		return []string{string(ScopeReadRepository)}
+	case api.PermissionAreaUser:
+		return []string{string(ScopeReadUser)}
+	}
+
+	return []string{}
 }
 
 func (g Gitlab) GetType() api.ServiceProviderType {
@@ -88,8 +127,108 @@ func (g Gitlab) GetType() api.ServiceProviderType {
 }
 
 func (g Gitlab) CheckRepositoryAccess(ctx context.Context, cl client.Client, accessCheck *api.SPIAccessCheck) (*api.SPIAccessCheckStatus, error) {
-	//TODO implement me
-	panic("implement me")
+	repoUrl := accessCheck.Spec.RepoUrl
+
+	status := &api.SPIAccessCheckStatus{
+		Type:            api.SPIRepoTypeGit,
+		ServiceProvider: api.ServiceProviderTypeGitLab,
+		Accessibility:   api.SPIAccessCheckAccessibilityUnknown,
+	}
+
+	repo, err := g.parseGitlabRepoUrl(accessCheck.Spec.RepoUrl)
+	if err != nil {
+		status.ErrorReason = api.SPIAccessCheckErrorBadURL
+		status.ErrorMessage = err.Error()
+		return status, nil
+	}
+
+	publicRepo, err := g.publicRepo(ctx, accessCheck)
+	if err != nil {
+		return nil, err
+	}
+	status.Accessible = publicRepo
+	if publicRepo {
+		status.Accessibility = api.SPIAccessCheckAccessibilityPublic
+		return status, nil
+	}
+
+	lg := log.FromContext(ctx)
+
+	tokens, lookupErr := g.lookup.Lookup(ctx, cl, accessCheck)
+	if lookupErr != nil {
+		lg.Error(lookupErr, "failed to lookup token for accesscheck", "accessCheck", accessCheck)
+		if !publicRepo {
+			status.ErrorReason = api.SPIAccessCheckErrorTokenLookupFailed
+			status.ErrorMessage = lookupErr.Error()
+		}
+		return status, nil
+	}
+
+	if len(tokens) < 1 {
+		lg.Info("we have no tokens for repository", "repo", repoUrl)
+		return status, nil
+	}
+
+	token := &tokens[0]
+	glClient, err := g.glClientBuilder.createAuthenticatedGlClient(ctx, token, g.baseUrl)
+	if err != nil {
+		status.ErrorReason = api.SPIAccessCheckErrorUnknownError
+		status.ErrorMessage = err.Error()
+		return status, err
+	}
+
+	project, response, err := glClient.Projects.GetProject(repo, nil, gitlab.WithContext(ctx))
+	if err != nil {
+		status.ErrorReason = api.SPIAccessCheckErrorRepoNotFound
+		status.ErrorMessage = err.Error()
+		return status, nil
+	}
+	if response.StatusCode != http.StatusOK {
+		status.ErrorReason = api.SPIAccessCheckErrorRepoNotFound
+		status.ErrorMessage = fmt.Sprintf("GitLab responded with non-ok status code: %d", response.StatusCode)
+		return status, nil
+	}
+	status.Accessible = true
+	// TODO: figure out how to categorize internal visibility
+	if project.Visibility == gitlab.PrivateVisibility || project.Visibility == gitlab.InternalVisibility {
+		status.Accessibility = api.SPIAccessCheckAccessibilityPrivate
+	}
+
+	return status, nil
+}
+
+// Temp
+func (g *Gitlab) publicRepo(ctx context.Context, accessCheck *api.SPIAccessCheck) (bool, error) {
+	lg := log.FromContext(ctx)
+	req, reqErr := http.NewRequestWithContext(ctx, "GET", accessCheck.Spec.RepoUrl, nil)
+	if reqErr != nil {
+		lg.Error(reqErr, "failed to prepare request", "accessCheck", accessCheck.Spec)
+		return false, fmt.Errorf("error while constructing HTTP request for access check to %s: %w", accessCheck.Spec.RepoUrl, reqErr)
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		lg.Error(err, "failed to request the repo", "repo", accessCheck.Spec.RepoUrl)
+		return false, fmt.Errorf("error performing HTTP request for access check to %v: %w", accessCheck.Spec.RepoUrl, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	} else if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	} else {
+		lg.Info("unexpected return code for repo", "repo", accessCheck.Spec.RepoUrl, "code", resp.StatusCode)
+		return false, nil
+	}
+}
+
+// Temp
+func (g *Gitlab) parseGitlabRepoUrl(repoUrl string) (repoPath string, err error) {
+	if !strings.HasPrefix(repoUrl, g.GetBaseUrl()) {
+		return "", fmt.Errorf("%w: '%s'", notGitlabUrlError, repoUrl)
+	}
+	return strings.TrimPrefix(repoUrl, g.GetBaseUrl()), nil
 }
 
 func (g Gitlab) GetOAuthEndpoint() string {
@@ -97,13 +236,34 @@ func (g Gitlab) GetOAuthEndpoint() string {
 }
 
 func (g Gitlab) MapToken(ctx context.Context, binding *api.SPIAccessTokenBinding, token *api.SPIAccessToken, tokenData *api.Token) (serviceprovider.AccessTokenMapper, error) {
-	//TODO implement me
-	panic("implement me")
+	return serviceprovider.DefaultMapToken(token, tokenData), nil
 }
 
 func (g Gitlab) Validate(ctx context.Context, validated serviceprovider.Validated) (serviceprovider.ValidationResult, error) {
-	//TODO implement me
-	panic("implement me")
+	ret := serviceprovider.ValidationResult{}
+
+	for _, p := range validated.Permissions().Required {
+		switch p.Area {
+		case api.PermissionAreaRepository,
+			api.PermissionAreaRepositoryMetadata,
+			api.PermissionAreaRegistry:
+			continue
+		case api.PermissionAreaUser:
+			if p.Type.IsWrite() {
+				ret.ScopeValidation = append(ret.ScopeValidation, userWritePermissionsNotSupportedError)
+			}
+		default:
+			ret.ScopeValidation = append(ret.ScopeValidation, fmt.Errorf("%w: '%s'", unsupportedAreaError, p.Area))
+		}
+	}
+
+	for _, s := range validated.Permissions().AdditionalScopes {
+		if !IsValidScope(s) {
+			ret.ScopeValidation = append(ret.ScopeValidation, fmt.Errorf("%w: '%s'", unsupportedScopeError, s))
+		}
+	}
+
+	return ret, nil
 }
 
 type gitlabProbe struct{}
@@ -111,8 +271,9 @@ type gitlabProbe struct{}
 var _ serviceprovider.Probe = (*gitlabProbe)(nil)
 
 func (p gitlabProbe) Examine(_ *http.Client, url string) (string, error) {
-	if strings.Contains(url, "gitlab") {
-		return "gitlab", nil //TODO implement real url
+	// TODO: improve logic
+	if strings.Contains(url, "https://gitlab.com") {
+		return "https://gitlab.com", nil
 	}
 	return "", nil
 }

--- a/pkg/serviceprovider/gitlab/gitlab.go
+++ b/pkg/serviceprovider/gitlab/gitlab.go
@@ -206,7 +206,7 @@ func (g *Gitlab) checkPrivateRepoAccess(ctx context.Context, token *api.SPIAcces
 		return err
 	}
 
-	project, response, err := glClient.Projects.GetProject(repo, nil, gitlab.WithContext(ctx))
+	project, response, err := glClient.Projects.GetProject(repo, nil, gitlab.WithContext(ctx)) //nolint:contextcheck // context present
 	if err != nil {
 		status.ErrorReason = api.SPIAccessCheckErrorRepoNotFound
 		status.ErrorMessage = err.Error()
@@ -230,7 +230,7 @@ func (g *Gitlab) checkPrivateRepoAccess(ctx context.Context, token *api.SPIAcces
 
 func (g *Gitlab) isPublicRepo(ctx context.Context, accessCheck *api.SPIAccessCheck) (bool, error) {
 	lg := log.FromContext(ctx)
-	req, err := http.NewRequestWithContext(ctx, "GET", accessCheck.Spec.RepoUrl, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, accessCheck.Spec.RepoUrl, nil)
 	if err != nil {
 		lg.Error(err, "failed to construct request to assess if repo is public", "accessCheck", accessCheck)
 		return false, fmt.Errorf("error while constructing HTTP request for access check to %s: %w", accessCheck.Spec.RepoUrl, err)

--- a/pkg/serviceprovider/gitlab/gitlab.go
+++ b/pkg/serviceprovider/gitlab/gitlab.go
@@ -206,7 +206,7 @@ func (g *Gitlab) checkPrivateRepoAccess(ctx context.Context, token *api.SPIAcces
 		return err
 	}
 
-	project, response, err := glClient.Projects.GetProject(repo, nil, gitlab.WithContext(ctx)) //nolint:contextcheck // context present
+	project, response, err := glClient.Projects.GetProject(repo, nil, gitlab.WithContext(ctx))
 	if err != nil {
 		status.ErrorReason = api.SPIAccessCheckErrorRepoNotFound
 		status.ErrorMessage = err.Error()

--- a/pkg/serviceprovider/gitlab/gitlab.go
+++ b/pkg/serviceprovider/gitlab/gitlab.go
@@ -20,7 +20,7 @@ import (
 
 var unsupportedScopeError = errors.New("unsupported scope for GitLab")
 var unsupportedAreaError = errors.New("unsupported permission area for GitLab")
-var userWritePermissionsNotSupportedError = errors.New("user write permissions are not supported by GitLab")
+var unsupportedUserWritePermissionError = errors.New("user write permission is not supported by GitLab")
 
 // Temp
 var notGitlabUrlError = errors.New("not a gitlab repository url")
@@ -239,7 +239,7 @@ func (g Gitlab) MapToken(ctx context.Context, binding *api.SPIAccessTokenBinding
 	return serviceprovider.DefaultMapToken(token, tokenData), nil
 }
 
-func (g Gitlab) Validate(ctx context.Context, validated serviceprovider.Validated) (serviceprovider.ValidationResult, error) {
+func (g Gitlab) Validate(_ context.Context, validated serviceprovider.Validated) (serviceprovider.ValidationResult, error) {
 	ret := serviceprovider.ValidationResult{}
 
 	for _, p := range validated.Permissions().Required {
@@ -250,7 +250,7 @@ func (g Gitlab) Validate(ctx context.Context, validated serviceprovider.Validate
 			continue
 		case api.PermissionAreaUser:
 			if p.Type.IsWrite() {
-				ret.ScopeValidation = append(ret.ScopeValidation, userWritePermissionsNotSupportedError)
+				ret.ScopeValidation = append(ret.ScopeValidation, unsupportedUserWritePermissionError)
 			}
 		default:
 			ret.ScopeValidation = append(ret.ScopeValidation, fmt.Errorf("%w: '%s'", unsupportedAreaError, p.Area))

--- a/pkg/serviceprovider/gitlab/gitlab.go
+++ b/pkg/serviceprovider/gitlab/gitlab.go
@@ -1,0 +1,118 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ serviceprovider.ServiceProvider = (*Gitlab)(nil)
+
+type Gitlab struct {
+	Configuration    *opconfig.OperatorConfiguration
+	lookup           serviceprovider.GenericLookup
+	metadataProvider *metadataProvider
+	httpClient       rest.HTTPClient
+	tokenStorage     tokenstorage.TokenStorage
+	baseUrl          string
+}
+
+var _ serviceprovider.ConstructorFunc = newGitlab
+
+func newGitlab(factory *serviceprovider.Factory, baseUrl string) (serviceprovider.ServiceProvider, error) {
+
+	// in Quay, we invalidate the individual cached repository records, because we're filling up the cache repo-by-repo
+	// therefore the metadata as a whole never gets refreshed.
+	cache := serviceprovider.NewMetadataCache(factory.KubernetesClient, &serviceprovider.NeverMetadataExpirationPolicy{})
+	mp := &metadataProvider{
+		tokenStorage:     factory.TokenStorage,
+		httpClient:       factory.HttpClient,
+		kubernetesClient: factory.KubernetesClient,
+		ttl:              factory.Configuration.TokenLookupCacheTtl,
+	}
+	return &Gitlab{
+		Configuration: factory.Configuration,
+		lookup: serviceprovider.GenericLookup{
+			ServiceProviderType: api.ServiceProviderTypeGitLab,
+			TokenFilter:         serviceprovider.NewFilter(factory.Configuration.TokenMatchPolicy, &tokenFilter{}),
+			MetadataProvider:    mp,
+			MetadataCache:       &cache,
+			RepoHostParser:      serviceprovider.RepoHostFromSchemelessUrl,
+		},
+		tokenStorage:     factory.TokenStorage,
+		metadataProvider: mp,
+		httpClient:       factory.HttpClient,
+		baseUrl:          baseUrl,
+	}, nil
+}
+
+func (g Gitlab) LookupToken(ctx context.Context, cl client.Client, binding *api.SPIAccessTokenBinding) (*api.SPIAccessToken, error) {
+	tokens, err := g.lookup.Lookup(ctx, cl, binding)
+	if err != nil {
+		return nil, fmt.Errorf("gitlab token lookup failure: %w", err)
+	}
+
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	return &tokens[0], nil
+}
+
+func (g Gitlab) PersistMetadata(ctx context.Context, _ client.Client, token *api.SPIAccessToken) error {
+	if err := g.lookup.PersistMetadata(ctx, token); err != nil {
+		return fmt.Errorf("failed to persiste gitlab metadata: %w", err)
+	}
+	return nil
+}
+
+func (g Gitlab) GetBaseUrl() string {
+	return g.BaseUrl
+}
+
+func (g Gitlab) OAuthScopesFor(permissions *api.Permissions) []string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (g Gitlab) GetType() api.ServiceProviderType {
+	return api.ServiceProviderTypeGitLab
+}
+
+func (g Gitlab) CheckRepositoryAccess(ctx context.Context, cl client.Client, accessCheck *api.SPIAccessCheck) (*api.SPIAccessCheckStatus, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (g Gitlab) GetOAuthEndpoint() string {
+	return g.Configuration.BaseUrl + "/gitlab/authenticate"
+}
+
+func (g Gitlab) MapToken(ctx context.Context, binding *api.SPIAccessTokenBinding, token *api.SPIAccessToken, tokenData *api.Token) (serviceprovider.AccessTokenMapper, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (g Gitlab) Validate(ctx context.Context, validated serviceprovider.Validated) (serviceprovider.ValidationResult, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+type gitlabProbe struct{}
+
+var _ serviceprovider.Probe = (*gitlabProbe)(nil)
+
+func (p gitlabProbe) Examine(_ *http.Client, url string) (string, error) {
+	if strings.Contains(url, "gitlab") {
+		return "gitlab", nil //TODO implement real url
+	}
+	return "", nil
+}

--- a/pkg/serviceprovider/gitlab/gitlab_test.go
+++ b/pkg/serviceprovider/gitlab/gitlab_test.go
@@ -152,7 +152,7 @@ func TestIsPublicRepo(t *testing.T) {
 	test(200, true)
 	test(404, false)
 	test(402, false)
-	test(301, false)
+	test(401, false)
 }
 
 func TestCheckRepositoryAccess(t *testing.T) {

--- a/pkg/serviceprovider/gitlab/gitlab_test.go
+++ b/pkg/serviceprovider/gitlab/gitlab_test.go
@@ -15,8 +15,24 @@
 package gitlab
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
 	"testing"
+	"time"
+
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
@@ -99,4 +115,211 @@ func TestOAuthScopesFor(t *testing.T) {
 			Area: api.PermissionAreaUser,
 		}},
 			AdditionalScopes: additionalScopes}))
+}
+
+func TestIsPublicRepo(t *testing.T) {
+	t.Run("http request fails", func(t *testing.T) {
+		expectedError := errors.New("expected error")
+		gitlab := Gitlab{httpClient: &http.Client{
+			Transport: util.FakeRoundTrip(func(r *http.Request) (*http.Response, error) {
+				return nil, expectedError
+			}),
+		}}
+
+		spiAccessCheck := &api.SPIAccessCheck{Spec: api.SPIAccessCheckSpec{RepoUrl: "gitlab.test"}}
+		isPublic, err := gitlab.isPublicRepo(context.TODO(), spiAccessCheck)
+		assert.False(t, isPublic)
+		assert.ErrorIs(t, err, expectedError)
+	})
+
+	test := func(statusCode int, expected bool) {
+		t.Run(fmt.Sprintf("should return %t for http status code %d", expected, statusCode), func(t *testing.T) {
+			gitlab := Gitlab{httpClient: &http.Client{
+				Transport: util.FakeRoundTrip(func(r *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: statusCode,
+					}, nil
+				}),
+			}}
+
+			spiAccessCheck := &api.SPIAccessCheck{Spec: api.SPIAccessCheckSpec{RepoUrl: "gitlab.test"}}
+			isPublic, err := gitlab.isPublicRepo(context.TODO(), spiAccessCheck)
+			assert.NoError(t, err)
+			assert.Equal(t, expected, isPublic)
+		})
+	}
+
+	test(200, true)
+	test(404, false)
+	test(402, false)
+	test(301, false)
+}
+
+func TestCheckRepositoryAccess(t *testing.T) {
+	k8sClient := mockK8sClient()
+	gitlab := mockGitlab(k8sClient, http.StatusOK, nil, nil)
+
+	ac := api.SPIAccessCheck{
+		Spec: api.SPIAccessCheckSpec{RepoUrl: "https://gitlab.com/namespace/repo"},
+	}
+
+	status, err := gitlab.CheckRepositoryAccess(context.TODO(), k8sClient, &ac)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, status)
+	assert.True(t, status.Accessible)
+	assert.Equal(t, api.SPIRepoTypeGit, status.Type)
+	assert.Equal(t, api.ServiceProviderTypeGitLab, status.ServiceProvider)
+	assert.Equal(t, api.SPIAccessCheckAccessibilityPublic, status.Accessibility)
+}
+
+func TestCheckRepositoryAccess_FailWithGithubHttp(t *testing.T) {
+	k8sClient := mockK8sClient()
+	gitlab := mockGitlab(k8sClient, http.StatusServiceUnavailable, fmt.Errorf("fail to talk to github api"), nil)
+
+	ac := api.SPIAccessCheck{
+		Spec: api.SPIAccessCheckSpec{RepoUrl: "https://gitlab.com/namespace/repo"},
+	}
+
+	status, err := gitlab.CheckRepositoryAccess(context.TODO(), k8sClient, &ac)
+
+	assert.Error(t, err)
+	assert.Nil(t, status)
+}
+
+func TestCheckRepositoryAccess_Private(t *testing.T) {
+	k8sClient := mockK8sClient()
+	gitlab := mockGitlab(k8sClient, http.StatusNotFound, nil, nil)
+	ac := api.SPIAccessCheck{
+		Spec: api.SPIAccessCheckSpec{RepoUrl: "https://gitlab.com/namespace/repo"},
+	}
+
+	status, err := gitlab.CheckRepositoryAccess(context.TODO(), k8sClient, &ac)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, status)
+	assert.False(t, status.Accessible)
+	assert.Equal(t, api.SPIRepoTypeGit, status.Type)
+	assert.Equal(t, api.ServiceProviderTypeGitLab, status.ServiceProvider)
+	assert.Equal(t, api.SPIAccessCheckAccessibilityUnknown, status.Accessibility)
+}
+
+func TestCheckRepositoryAccess_LookupFailing_With_PublicRepo(t *testing.T) {
+	k8sClient := mockK8sClient()
+	gitlab := mockGitlab(k8sClient, http.StatusOK, nil, errors.New("expected error"))
+
+	accessCheck := api.SPIAccessCheck{
+		Spec: api.SPIAccessCheckSpec{RepoUrl: "https://gitlab.com/namespace/repo"},
+	}
+	status, err := gitlab.CheckRepositoryAccess(context.TODO(), k8sClient, &accessCheck)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, status)
+	assert.True(t, status.Accessible)
+	assert.Equal(t, api.SPIRepoTypeGit, status.Type)
+	assert.Equal(t, api.ServiceProviderTypeGitLab, status.ServiceProvider)
+	assert.Equal(t, api.SPIAccessCheckAccessibilityPublic, status.Accessibility)
+	assert.Empty(t, status.ErrorReason)
+	assert.Empty(t, status.ErrorMessage)
+}
+
+func TestCheckRepositoryAccess_LookupFailing_With_PrivateRepo(t *testing.T) {
+	k8sClient := mockK8sClient()
+	expectedError := errors.New("expected error")
+	gitlab := mockGitlab(k8sClient, http.StatusNotFound, nil, expectedError)
+
+	accessCheck := api.SPIAccessCheck{
+		Spec: api.SPIAccessCheckSpec{RepoUrl: "https://gitlab.com/namespace/repo"},
+	}
+	status, err := gitlab.CheckRepositoryAccess(context.TODO(), k8sClient, &accessCheck)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, status)
+	assert.False(t, status.Accessible)
+	assert.Equal(t, api.SPIRepoTypeGit, status.Type)
+	assert.Equal(t, api.ServiceProviderTypeGitLab, status.ServiceProvider)
+	assert.Equal(t, api.SPIAccessCheckAccessibilityUnknown, status.Accessibility)
+	assert.Equal(t, api.SPIAccessCheckErrorTokenLookupFailed, status.ErrorReason)
+	assert.Contains(t, status.ErrorMessage, expectedError.Error())
+}
+
+func TestCheckRepositoryAccess_With_MatchingTokens(t *testing.T) {
+	k8sClient := mockK8sClient()
+	gitlab := mockGitlab(k8sClient, http.StatusOK, nil, nil)
+	ac := api.SPIAccessCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "access-check",
+			Namespace: "ac-namespace",
+		},
+		Spec: api.SPIAccessCheckSpec{RepoUrl: "https://gitlab.com/namespace/repo"},
+	}
+	status, err := gitlab.CheckRepositoryAccess(context.TODO(), k8sClient, &ac)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, status)
+}
+
+func mockGitlab(cl client.Client, returnCode int, responseError error, lookupError error) *Gitlab {
+	metadataCache := serviceprovider.NewMetadataCache(cl, &serviceprovider.NeverMetadataExpirationPolicy{})
+	tokenStorageMock := tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+		return &api.Token{AccessToken: "access_tolkien"}, nil
+	}}
+
+	httpClientMock := &http.Client{
+		Transport: util.FakeRoundTrip(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: returnCode,
+				Header:     http.Header{},
+				Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"message": "one_ring_to_rule_them_all"}`))),
+				Request:    r,
+			}, responseError
+		}),
+	}
+
+	return &Gitlab{httpClient: httpClientMock,
+		lookup: serviceprovider.GenericLookup{
+			ServiceProviderType: api.ServiceProviderTypeGitLab,
+			MetadataCache:       &metadataCache,
+			TokenFilter: struct {
+				serviceprovider.TokenFilterFunc
+			}{
+				TokenFilterFunc: func(ctx context.Context, matchable serviceprovider.Matchable, token *api.SPIAccessToken) (bool, error) {
+					return true, lookupError
+				},
+			},
+			RepoHostParser: serviceprovider.RepoHostFromUrl,
+		},
+		tokenStorage: tokenStorageMock,
+		glClientBuilder: gitlabClientBuilder{
+			httpClient:   httpClientMock,
+			tokenStorage: tokenStorageMock,
+		},
+	}
+}
+
+func mockK8sClient() client.WithWatch {
+	token := &api.SPIAccessToken{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "token",
+			Namespace: "accessCheck-namespace",
+			Labels: map[string]string{
+				api.ServiceProviderTypeLabel: string(api.ServiceProviderTypeGitLab),
+				api.ServiceProviderHostLabel: "gitlab.com",
+			},
+		},
+		Spec: api.SPIAccessTokenSpec{
+			ServiceProviderUrl: "https://gitlab.com",
+		},
+		Status: api.SPIAccessTokenStatus{
+			Phase: api.SPIAccessTokenPhaseReady,
+			TokenMetadata: &api.TokenMetadata{
+				LastRefreshTime: time.Now().Add(time.Hour).Unix(),
+			},
+		},
+	}
+
+	sch := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(sch))
+	utilruntime.Must(api.AddToScheme(sch))
+	return fake.NewClientBuilder().WithScheme(sch).WithObjects(token).Build()
 }

--- a/pkg/serviceprovider/gitlab/gitlab_test.go
+++ b/pkg/serviceprovider/gitlab/gitlab_test.go
@@ -1,3 +1,17 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gitlab
 
 import (
@@ -56,7 +70,7 @@ func TestOAuthScopesFor(t *testing.T) {
 	}
 
 	t.Run("read repository",
-		hasExpectedScopes([]string{string(ScopeReadRepository)},
+		hasExpectedScopes([]string{string(ScopeReadRepository), string(ScopeReadUser)},
 			api.Permissions{Required: []api.Permission{
 				{
 					Area: api.PermissionAreaRepository,
@@ -65,7 +79,7 @@ func TestOAuthScopesFor(t *testing.T) {
 			}}))
 
 	t.Run("write repository and registry",
-		hasExpectedScopes([]string{string(ScopeWriteRepository), string(ScopeWriteRegistry)},
+		hasExpectedScopes([]string{string(ScopeWriteRepository), string(ScopeWriteRegistry), string(ScopeReadUser)},
 			api.Permissions{Required: []api.Permission{
 				{
 					Area: api.PermissionAreaRepository,

--- a/pkg/serviceprovider/gitlab/gitlab_test.go
+++ b/pkg/serviceprovider/gitlab/gitlab_test.go
@@ -1,0 +1,88 @@
+package gitlab
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidate(t *testing.T) {
+	gitlab := &Gitlab{}
+	validationResult, err := gitlab.Validate(context.TODO(), &api.SPIAccessToken{
+		Spec: api.SPIAccessTokenSpec{
+			Permissions: api.Permissions{
+				Required: []api.Permission{
+					{
+						Type: api.PermissionTypeWrite,
+						Area: api.PermissionAreaUser,
+					},
+					{
+						Type: api.PermissionTypeRead,
+						Area: api.PermissionAreaWebhooks,
+					},
+					{
+						Type: api.PermissionTypeReadWrite,
+						Area: api.PermissionAreaRepository,
+					},
+				},
+				AdditionalScopes: []string{string(ScopeSudo), string(ScopeProfile), "darth", string(ScopeWriteRepository), "vader"},
+			},
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(validationResult.ScopeValidation))
+	assert.ErrorIs(t, validationResult.ScopeValidation[0], unsupportedUserWritePermissionError)
+	assert.ErrorIs(t, validationResult.ScopeValidation[1], unsupportedAreaError)
+	assert.ErrorContains(t, validationResult.ScopeValidation[1], string(api.PermissionAreaWebhooks))
+	assert.ErrorIs(t, validationResult.ScopeValidation[2], unsupportedScopeError)
+	assert.ErrorContains(t, validationResult.ScopeValidation[2], "darth")
+	assert.ErrorIs(t, validationResult.ScopeValidation[3], unsupportedScopeError)
+	assert.ErrorContains(t, validationResult.ScopeValidation[3], "vader")
+}
+
+func TestOAuthScopesFor(t *testing.T) {
+	gitlab := &Gitlab{}
+	hasExpectedScopes := func(expectedScopes []string, permissions api.Permissions) func(t *testing.T) {
+		return func(t *testing.T) {
+			actualScopes := gitlab.OAuthScopesFor(&permissions)
+			assert.Equal(t, len(expectedScopes), len(actualScopes))
+			for _, s := range expectedScopes {
+				assert.Contains(t, actualScopes, s)
+			}
+		}
+	}
+
+	t.Run("read repository",
+		hasExpectedScopes([]string{string(ScopeReadRepository)},
+			api.Permissions{Required: []api.Permission{
+				{
+					Area: api.PermissionAreaRepository,
+					Type: api.PermissionTypeRead,
+				},
+			}}))
+
+	t.Run("write repository and registry",
+		hasExpectedScopes([]string{string(ScopeWriteRepository), string(ScopeWriteRegistry)},
+			api.Permissions{Required: []api.Permission{
+				{
+					Area: api.PermissionAreaRepository,
+					Type: api.PermissionTypeWrite,
+				},
+				{
+					Area: api.PermissionAreaRegistry,
+					Type: api.PermissionTypeWrite,
+				},
+			}}))
+
+	additionalScopes := []string{string(ScopeSudo), string(ScopeApi), string(ScopeReadApi), string(ScopeReadUser)}
+	t.Run("read user and additional scopes", hasExpectedScopes(
+		additionalScopes,
+		api.Permissions{Required: []api.Permission{{
+			Type: api.PermissionTypeRead,
+			Area: api.PermissionAreaUser,
+		}},
+			AdditionalScopes: additionalScopes}))
+}

--- a/pkg/serviceprovider/gitlab/gitlabclientbuilder.go
+++ b/pkg/serviceprovider/gitlab/gitlabclientbuilder.go
@@ -1,3 +1,17 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gitlab
 
 import (
@@ -17,14 +31,14 @@ type gitlabClientBuilder struct {
 	tokenStorage tokenstorage.TokenStorage
 }
 
-func (g *gitlabClientBuilder) createAuthenticatedGlClient(ctx context.Context, spiAccessToken *api.SPIAccessToken, baseUrl string) (*gitlab.Client, error) {
+func (builder *gitlabClientBuilder) createGitlabAuthClient(ctx context.Context, spiAccessToken *api.SPIAccessToken, baseUrl string) (*gitlab.Client, error) {
 	lg := log.FromContext(ctx)
-	tokenData, err := g.tokenStorage.Get(ctx, spiAccessToken)
+	tokenData, err := builder.tokenStorage.Get(ctx, spiAccessToken)
 	if err != nil {
 		lg.Error(err, "failed to get token from storage for", "token", spiAccessToken)
 		return nil, fmt.Errorf("failed to get token from storage for %s/%s: %w", spiAccessToken.Namespace, spiAccessToken.Name, err)
 	}
-	lg.V(logs.DebugLevel).Info("Created new github client", "SPIAccessToken", spiAccessToken)
-	return gitlab.NewOAuthClient(tokenData.AccessToken, gitlab.WithHTTPClient(g.httpClient), gitlab.WithBaseURL(baseUrl))
+	lg.V(logs.DebugLevel).Info("Created new gitlab client", "SPIAccessToken", spiAccessToken)
+	return gitlab.NewOAuthClient(tokenData.AccessToken, gitlab.WithHTTPClient(builder.httpClient), gitlab.WithBaseURL(baseUrl))
 
 }

--- a/pkg/serviceprovider/gitlab/gitlabclientbuilder.go
+++ b/pkg/serviceprovider/gitlab/gitlabclientbuilder.go
@@ -36,9 +36,15 @@ func (builder *gitlabClientBuilder) createGitlabAuthClient(ctx context.Context, 
 	tokenData, err := builder.tokenStorage.Get(ctx, spiAccessToken)
 	if err != nil {
 		lg.Error(err, "failed to get token from storage for", "token", spiAccessToken)
-		return nil, fmt.Errorf("failed to get token from storage for %s/%s: %w", spiAccessToken.Namespace, spiAccessToken.Name, err)
+		return nil, fmt.Errorf("failed to get token from storage for %s/%s: %w",
+			spiAccessToken.Namespace, spiAccessToken.Name, err)
 	}
-	lg.V(logs.DebugLevel).Info("Created new gitlab client", "SPIAccessToken", spiAccessToken)
-	return gitlab.NewOAuthClient(tokenData.AccessToken, gitlab.WithHTTPClient(builder.httpClient), gitlab.WithBaseURL(baseUrl))
 
+	client, err := gitlab.NewOAuthClient(tokenData.AccessToken, gitlab.WithHTTPClient(builder.httpClient), gitlab.WithBaseURL(baseUrl))
+	if err != nil {
+		return nil, fmt.Errorf("failed to created new authenticated gitlab client for SPIAccessToken %s/%s: %w",
+			spiAccessToken.Namespace, spiAccessToken.Name, err)
+	}
+	lg.V(logs.DebugLevel).Info("new authenticated gitlab client successfully created", "SPIAccessToken", spiAccessToken)
+	return client, nil
 }

--- a/pkg/serviceprovider/gitlab/gitlabclientbuilder.go
+++ b/pkg/serviceprovider/gitlab/gitlabclientbuilder.go
@@ -1,0 +1,30 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/xanzy/go-gitlab"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type gitlabClientBuilder struct {
+	httpClient   *http.Client
+	tokenStorage tokenstorage.TokenStorage
+}
+
+func (g *gitlabClientBuilder) createAuthenticatedGlClient(ctx context.Context, spiAccessToken *api.SPIAccessToken, baseUrl string) (*gitlab.Client, error) {
+	lg := log.FromContext(ctx)
+	tokenData, err := g.tokenStorage.Get(ctx, spiAccessToken)
+	if err != nil {
+		lg.Error(err, "failed to get token from storage for", "token", spiAccessToken)
+		return nil, fmt.Errorf("failed to get token from storage for %s/%s: %w", spiAccessToken.Namespace, spiAccessToken.Name, err)
+	}
+	lg.V(logs.DebugLevel).Info("Created new github client", "SPIAccessToken", spiAccessToken)
+	return gitlab.NewOAuthClient(tokenData.AccessToken, gitlab.WithHTTPClient(g.httpClient), gitlab.WithBaseURL(baseUrl))
+
+}

--- a/pkg/serviceprovider/gitlab/metadataprovider.go
+++ b/pkg/serviceprovider/gitlab/metadataprovider.go
@@ -1,0 +1,26 @@
+package gitlab
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type metadataProvider struct {
+	tokenStorage     tokenstorage.TokenStorage
+	httpClient       *http.Client
+	kubernetesClient client.Client
+	ttl              time.Duration
+}
+
+func (m metadataProvider) Fetch(ctx context.Context, token *api.SPIAccessToken) (*api.TokenMetadata, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+var _ serviceprovider.MetadataProvider = (*metadataProvider)(nil)

--- a/pkg/serviceprovider/gitlab/metadataprovider.go
+++ b/pkg/serviceprovider/gitlab/metadataprovider.go
@@ -1,3 +1,17 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gitlab
 
 import (
@@ -37,42 +51,37 @@ func (p metadataProvider) Fetch(ctx context.Context, token *api.SPIAccessToken) 
 
 	state := &TokenState{}
 
-	glClient, err := p.glClientBuilder.createAuthenticatedGlClient(ctx, token, p.baseUrl)
+	glClient, err := p.glClientBuilder.createGitlabAuthClient(ctx, token, p.baseUrl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create authenticated GitHub client: %w", err)
 	}
-
-	//if err := (&AllAccessibleRepos{}).FetchAll(ctx, ghClient, data.AccessToken, state); err != nil {
-	//	return nil, err
-	//}
 
 	username, userId, scopes, err := p.fetchUserAndScopes(ctx, glClient)
 	if err != nil {
 		return nil, err
 	}
 
-	js, err := json.Marshal(state)
+	// TODO: implement repository querying
+	rawState, err := json.Marshal(state)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling the state: %w", err)
 	}
 
 	metadata := &api.TokenMetadata{}
-
 	metadata.UserId = userId
 	metadata.Username = username
 	metadata.Scopes = scopes
-	metadata.ServiceProviderState = js
+	metadata.ServiceProviderState = rawState
 
 	return metadata, nil
 }
 
-// fetchUserAndScopes fetches the scopes and the details of the user associated with the context
 func (p metadataProvider) fetchUserAndScopes(ctx context.Context, gitlabClient *gitlab.Client) (userName string, userId string, scopes []string, err error) {
 	lg := log.FromContext(ctx)
 	usr, resp, err := gitlabClient.Users.CurrentUser(gitlab.WithContext(ctx))
 	if err != nil {
 		lg.Error(err, "error during fetching user metadata from GitLab")
-		err = fmt.Errorf("failed to fetch user info: %w", err)
+		err = fmt.Errorf("failed to fetch user metadate from GitLab: %w", err)
 		return
 	}
 	if resp.StatusCode != 200 {
@@ -80,28 +89,29 @@ func (p metadataProvider) fetchUserAndScopes(ctx context.Context, gitlabClient *
 		return "", "", nil, nil
 	}
 
-	type tokenResponseBody struct {
-		scope []string
-	}
-	responseBody := tokenResponseBody{}
-
+	tokenInfoResponse := struct {
+		Scopes []string `json:"scope"`
+	}{}
 	req, err := retryablehttp.NewRequestWithContext(ctx, "GET", p.baseUrl+"/oauth/token/info", nil)
 	if err != nil {
 		return "", "", nil, err
 	}
-	tokenResp, err := gitlabClient.Do(req, &responseBody)
+
+	tokenResp, err := gitlabClient.Do(req, &tokenInfoResponse)
 	if err != nil {
+		lg.Error(err, "error during fetching token scopes from GitLab")
 		return "", "", nil, err
 	}
+
 	if tokenResp.StatusCode != 200 {
-		lg.Error(err, "error during fetching user metadata from GitLab", "status", resp.StatusCode)
+		lg.Error(err, "non-ok status during fetching token scopes from GitLab", "status", resp.StatusCode)
 		return "", "", nil, nil
 	}
 
-	scopes = responseBody.scope
+	scopes = tokenInfoResponse.Scopes
 	userId = strconv.FormatInt(int64(usr.ID), 10)
 	userName = usr.Username
-	lg.V(logs.DebugLevel).Info("Fetched user metadata from GitLab", "login", userName, "userid", userId, "scopes", scopes)
+	lg.V(logs.DebugLevel).Info("fetched user metadata from GitLab", "login", userName, "userid", userId, "scopes", scopes)
 	return
 }
 

--- a/pkg/serviceprovider/gitlab/metadataprovider.go
+++ b/pkg/serviceprovider/gitlab/metadataprovider.go
@@ -2,25 +2,107 @@ package gitlab
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
-	"time"
+	"strconv"
 
+	"github.com/hashicorp/go-retryablehttp"
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/xanzy/go-gitlab"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type metadataProvider struct {
-	tokenStorage     tokenstorage.TokenStorage
-	httpClient       *http.Client
-	kubernetesClient client.Client
-	ttl              time.Duration
+	tokenStorage    tokenstorage.TokenStorage
+	httpClient      *http.Client
+	glClientBuilder gitlabClientBuilder
+	baseUrl         string
 }
 
-func (m metadataProvider) Fetch(ctx context.Context, token *api.SPIAccessToken) (*api.TokenMetadata, error) {
-	//TODO implement me
-	panic("implement me")
+func (p metadataProvider) Fetch(ctx context.Context, token *api.SPIAccessToken) (*api.TokenMetadata, error) {
+	lg := log.FromContext(ctx, "tokenName", token.Name, "tokenNamespace", token.Namespace)
+
+	data, err := p.tokenStorage.Get(ctx, token)
+	if err != nil {
+		lg.Error(err, "failed to get the token metadata")
+		return nil, fmt.Errorf("failed to get the token metadata: %w", err)
+	}
+	if data == nil {
+		return nil, nil
+	}
+
+	state := &TokenState{}
+
+	glClient, err := p.glClientBuilder.createAuthenticatedGlClient(ctx, token, p.baseUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authenticated GitHub client: %w", err)
+	}
+
+	//if err := (&AllAccessibleRepos{}).FetchAll(ctx, ghClient, data.AccessToken, state); err != nil {
+	//	return nil, err
+	//}
+
+	username, userId, scopes, err := p.fetchUserAndScopes(ctx, glClient)
+	if err != nil {
+		return nil, err
+	}
+
+	js, err := json.Marshal(state)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling the state: %w", err)
+	}
+
+	metadata := &api.TokenMetadata{}
+
+	metadata.UserId = userId
+	metadata.Username = username
+	metadata.Scopes = scopes
+	metadata.ServiceProviderState = js
+
+	return metadata, nil
+}
+
+// fetchUserAndScopes fetches the scopes and the details of the user associated with the context
+func (p metadataProvider) fetchUserAndScopes(ctx context.Context, gitlabClient *gitlab.Client) (userName string, userId string, scopes []string, err error) {
+	lg := log.FromContext(ctx)
+	usr, resp, err := gitlabClient.Users.CurrentUser(gitlab.WithContext(ctx))
+	if err != nil {
+		lg.Error(err, "error during fetching user metadata from GitLab")
+		err = fmt.Errorf("failed to fetch user info: %w", err)
+		return
+	}
+	if resp.StatusCode != 200 {
+		lg.Error(err, "error during fetching user metadata from GitLab", "status", resp.StatusCode)
+		return "", "", nil, nil
+	}
+
+	type tokenResponseBody struct {
+		scope []string
+	}
+	responseBody := tokenResponseBody{}
+
+	req, err := retryablehttp.NewRequestWithContext(ctx, "GET", p.baseUrl+"/oauth/token/info", nil)
+	if err != nil {
+		return "", "", nil, err
+	}
+	tokenResp, err := gitlabClient.Do(req, &responseBody)
+	if err != nil {
+		return "", "", nil, err
+	}
+	if tokenResp.StatusCode != 200 {
+		lg.Error(err, "error during fetching user metadata from GitLab", "status", resp.StatusCode)
+		return "", "", nil, nil
+	}
+
+	scopes = responseBody.scope
+	userId = strconv.FormatInt(int64(usr.ID), 10)
+	userName = usr.Username
+	lg.V(logs.DebugLevel).Info("Fetched user metadata from GitLab", "login", userName, "userid", userId, "scopes", scopes)
+	return
 }
 
 var _ serviceprovider.MetadataProvider = (*metadataProvider)(nil)

--- a/pkg/serviceprovider/gitlab/metadataprovider_test.go
+++ b/pkg/serviceprovider/gitlab/metadataprovider_test.go
@@ -38,32 +38,29 @@ var tokenStorageGet = func(ctx context.Context, token *api.SPIAccessToken) (*api
 	}, nil
 }
 
-func TestFetch(t *testing.T) {
+func TestFetch_Success(t *testing.T) {
 	httpClient := &http.Client{
 		Transport: util.FakeRoundTrip(func(r *http.Request) (*http.Response, error) {
-
 			if strings.Contains(r.URL.String(), "/user") {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"id": 42, "username": "user42"}`))),
 				}, nil
 			}
-			if strings.Contains(r.URL.String(), "/token/info") {
+			if strings.Contains(r.URL.String(), gitlabOAuthTokenInfoPath) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"scope": ["write_repository", "read_registry"]}`))),
 				}, nil
 			}
-			return &http.Response{
-				StatusCode: http.StatusNotFound,
-			}, nil
+
+			return nil, nil
 		}),
 	}
 
 	ts := tokenstorage.TestTokenStorage{
 		GetImpl: tokenStorageGet,
 	}
-
 	mp := metadataProvider{
 		glClientBuilder: gitlabClientBuilder{
 			httpClient:   httpClient,
@@ -84,18 +81,98 @@ func TestFetch(t *testing.T) {
 	assert.NotEmpty(t, data.ServiceProviderState)
 }
 
-func TestFetch_Fail(t *testing.T) {
-	expectedError := errors.New("math: square root of negative number")
+func TestFetch_Success_PatScopes(t *testing.T) {
 	httpCl := &http.Client{
 		Transport: util.FakeRoundTrip(func(r *http.Request) (*http.Response, error) {
 			if strings.Contains(r.URL.String(), "/user") {
-				return nil, expectedError
-			} else {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"id": 42, "username": "user42"}`))),
 				}, nil
 			}
+			if strings.Contains(r.URL.String(), gitlabOAuthTokenInfoPath) {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"error": "invalid_token"}`))),
+				}, nil
+			}
+			if strings.Contains(r.URL.String(), gitlabPatInfoPath) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"scope": ["write_repository", "read_registry"]}`))),
+				}, nil
+			}
+			return nil, nil
+		}),
+	}
+
+	ts := tokenstorage.TestTokenStorage{
+		GetImpl: tokenStorageGet,
+	}
+
+	mp := metadataProvider{
+		glClientBuilder: gitlabClientBuilder{
+			httpClient:   httpCl,
+			tokenStorage: ts,
+		},
+		httpClient:   httpCl,
+		tokenStorage: &ts,
+	}
+
+	token := api.SPIAccessToken{}
+	data, err := mp.Fetch(context.TODO(), &token)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, data)
+	assert.Equal(t, "42", data.UserId)
+	assert.Equal(t, "user42", data.Username)
+	assert.Equal(t, []string{"write_repository", "read_registry"}, data.Scopes)
+	assert.NotEmpty(t, data.ServiceProviderState)
+}
+
+func TestFetch_Fail_User(t *testing.T) {
+	expectedError := errors.New("success is the progressive realization of a worthy ideal")
+	httpCl := &http.Client{
+		Transport: util.FakeRoundTrip(func(r *http.Request) (*http.Response, error) {
+			if strings.Contains(r.URL.String(), "/user") {
+				return nil, expectedError
+			}
+			return nil, nil
+		}),
+	}
+
+	ts := tokenstorage.TestTokenStorage{
+		GetImpl: tokenStorageGet,
+	}
+	mp := metadataProvider{
+		glClientBuilder: gitlabClientBuilder{
+			httpClient:   httpCl,
+			tokenStorage: ts,
+		},
+		httpClient:   httpCl,
+		tokenStorage: &ts,
+	}
+
+	tkn := api.SPIAccessToken{}
+	data, err := mp.Fetch(context.TODO(), &tkn)
+	assert.Error(t, err, expectedError)
+	assert.Nil(t, data)
+}
+
+func TestFetch_Fail_Scopes(t *testing.T) {
+	expectedError := errors.New("be the change that you wish to see in the world")
+	httpCl := &http.Client{
+		Transport: util.FakeRoundTrip(func(r *http.Request) (*http.Response, error) {
+			if strings.Contains(r.URL.String(), "/user") {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"id": 42, "username": "user42"}`))),
+				}, nil
+			}
+			if strings.Contains(r.URL.String(), gitlabOAuthTokenInfoPath) || strings.Contains(r.URL.String(), gitlabPatInfoPath) {
+				return nil, expectedError
+			}
+			return nil, nil
 		}),
 	}
 

--- a/pkg/serviceprovider/gitlab/metadataprovider_test.go
+++ b/pkg/serviceprovider/gitlab/metadataprovider_test.go
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlab
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetch(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: util.FakeRoundTrip(func(r *http.Request) (*http.Response, error) {
+
+			if strings.Contains(r.URL.String(), "/user") {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"id": 42, "username": "user42"}`))),
+				}, nil
+			}
+			if strings.Contains(r.URL.String(), "/token/info") {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"scope": ["write_repository", "read_registry"]}`))),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: 400,
+				Body:       io.NopCloser(bytes.NewBuffer([]byte(""))),
+			}, nil
+		}),
+	}
+
+	ts := tokenstorage.TestTokenStorage{
+		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
+			return &api.Token{
+				AccessToken:  "token",
+				TokenType:    "Grizzly Bear-er",
+				RefreshToken: "refresh-token",
+				Expiry:       0,
+			}, nil
+		},
+	}
+	githubClientBuilder := gitlabClientBuilder{
+		httpClient:   httpClient,
+		tokenStorage: ts,
+	}
+
+	mp := metadataProvider{
+		glClientBuilder: githubClientBuilder,
+		httpClient:      httpClient,
+		tokenStorage:    &ts,
+	}
+
+	token := api.SPIAccessToken{}
+	data, err := mp.Fetch(context.TODO(), &token)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, data)
+	assert.Equal(t, "42", data.UserId)
+	assert.Equal(t, "user42", data.Username)
+	assert.Equal(t, []string{"write_repository", "read_registry"}, data.Scopes)
+	assert.NotEmpty(t, data.ServiceProviderState)
+}

--- a/pkg/serviceprovider/gitlab/metadataprovider_test.go
+++ b/pkg/serviceprovider/gitlab/metadataprovider_test.go
@@ -99,7 +99,7 @@ func TestFetch_Success_PatScopes(t *testing.T) {
 			if strings.Contains(r.URL.String(), gitlabPatInfoPath) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"scope": ["write_repository", "read_registry"]}`))),
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"scopes": ["write_repository", "read_registry"]}`))),
 				}, nil
 			}
 			return nil, nil

--- a/pkg/serviceprovider/gitlab/state.go
+++ b/pkg/serviceprovider/gitlab/state.go
@@ -31,6 +31,7 @@ const (
 )
 
 type TokenState struct {
+	// TODO: implement
 }
 
 func (s Scope) Implies(other Scope) bool {

--- a/pkg/serviceprovider/gitlab/state.go
+++ b/pkg/serviceprovider/gitlab/state.go
@@ -1,3 +1,17 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gitlab
 
 type Scope string

--- a/pkg/serviceprovider/gitlab/state.go
+++ b/pkg/serviceprovider/gitlab/state.go
@@ -1,0 +1,55 @@
+package gitlab
+
+type Scope string
+
+const (
+	ScopeApi             Scope = "api"
+	ScopeReadApi         Scope = "read_api"
+	ScopeReadUser        Scope = "read_user"
+	ScopeReadRepository  Scope = "read_repository"
+	ScopeWriteRepository Scope = "write_repository"
+	ScopeReadRegistry    Scope = "read_registry"
+	ScopeWriteRegistry   Scope = "write_registry"
+	ScopeSudo            Scope = "sudo" // less understood scopes bellow
+	ScopeOpenid          Scope = "openid"
+	ScopeProfile         Scope = "profile"
+	ScopeEmail           Scope = "email"
+)
+
+type TokenState struct {
+}
+
+func (s Scope) Implies(other Scope) bool {
+	if s == other {
+		return true
+	}
+	switch s {
+	case ScopeApi:
+		return other == ScopeReadApi || other == ScopeReadUser || other == ScopeReadRepository || other == ScopeWriteRepository || other == ScopeReadRegistry || other == ScopeWriteRegistry
+	case ScopeReadApi:
+		return other == ScopeReadUser || other == ScopeReadRepository || other == ScopeReadRegistry
+	case ScopeWriteRepository:
+		return other == ScopeReadRepository
+	case ScopeWriteRegistry:
+		return other == ScopeReadRegistry
+	}
+	return false
+}
+
+func IsValidScope(scope string) bool {
+	switch Scope(scope) {
+	case ScopeApi,
+		ScopeReadApi,
+		ScopeReadUser,
+		ScopeReadRepository,
+		ScopeWriteRepository,
+		ScopeReadRegistry,
+		ScopeWriteRegistry,
+		ScopeSudo,
+		ScopeOpenid,
+		ScopeProfile,
+		ScopeEmail:
+		return true
+	}
+	return false
+}

--- a/pkg/serviceprovider/gitlab/state.go
+++ b/pkg/serviceprovider/gitlab/state.go
@@ -24,7 +24,7 @@ const (
 	ScopeWriteRepository Scope = "write_repository"
 	ScopeReadRegistry    Scope = "read_registry"
 	ScopeWriteRegistry   Scope = "write_registry"
-	ScopeSudo            Scope = "sudo" // less understood scopes bellow
+	ScopeSudo            Scope = "sudo" // less understood and less relevant scopes begin
 	ScopeOpenid          Scope = "openid"
 	ScopeProfile         Scope = "profile"
 	ScopeEmail           Scope = "email"
@@ -39,7 +39,8 @@ func (s Scope) Implies(other Scope) bool {
 	}
 	switch s {
 	case ScopeApi:
-		return other == ScopeReadApi || other == ScopeReadUser || other == ScopeReadRepository || other == ScopeWriteRepository || other == ScopeReadRegistry || other == ScopeWriteRegistry
+		return other == ScopeReadApi || other == ScopeReadUser || other == ScopeReadRepository ||
+			other == ScopeWriteRepository || other == ScopeReadRegistry || other == ScopeWriteRegistry
 	case ScopeReadApi:
 		return other == ScopeReadUser || other == ScopeReadRepository || other == ScopeReadRegistry
 	case ScopeWriteRepository:

--- a/pkg/serviceprovider/gitlab/tokenfilter.go
+++ b/pkg/serviceprovider/gitlab/tokenfilter.go
@@ -30,15 +30,18 @@ type tokenFilter struct {
 }
 
 func (t tokenFilter) Matches(ctx context.Context, matchable serviceprovider.Matchable, token *api.SPIAccessToken) (bool, error) {
-	lg := log.FromContext(ctx, "matchableUrl", matchable.RepoUrl())
+	// We are currently matching only by scopes.
+	// This will change in the future when TokenState for GitLab tokens will be implemented.
 
+	lg := log.FromContext(ctx, "matchableUrl", matchable.RepoUrl())
 	lg.Info("matching", "token", token.Name)
+
 	if token.Status.TokenMetadata == nil {
 		return false, nil
 	}
 
 	requiredScopes := serviceprovider.GetAllScopes(translateToGitlabScopes, matchable.Permissions())
-	print(requiredScopes)
+
 	hasScope := func(scope Scope) bool {
 		for _, s := range token.Status.TokenMetadata.Scopes {
 			if Scope(s).Implies(scope) {

--- a/pkg/serviceprovider/gitlab/tokenfilter.go
+++ b/pkg/serviceprovider/gitlab/tokenfilter.go
@@ -25,9 +25,7 @@ import (
 
 var _ serviceprovider.TokenFilter = (*tokenFilter)(nil)
 
-type tokenFilter struct {
-	metadataProvider *metadataProvider
-}
+type tokenFilter struct{}
 
 func (t tokenFilter) Matches(ctx context.Context, matchable serviceprovider.Matchable, token *api.SPIAccessToken) (bool, error) {
 	// We are currently matching only by scopes.

--- a/pkg/serviceprovider/gitlab/tokenfilter.go
+++ b/pkg/serviceprovider/gitlab/tokenfilter.go
@@ -1,3 +1,17 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gitlab
 
 import (
@@ -24,6 +38,7 @@ func (t tokenFilter) Matches(ctx context.Context, matchable serviceprovider.Matc
 	}
 
 	requiredScopes := serviceprovider.GetAllScopes(translateToGitlabScopes, matchable.Permissions())
+	print(requiredScopes)
 	hasScope := func(scope Scope) bool {
 		for _, s := range token.Status.TokenMetadata.Scopes {
 			if Scope(s).Implies(scope) {

--- a/pkg/serviceprovider/gitlab/tokenfilter.go
+++ b/pkg/serviceprovider/gitlab/tokenfilter.go
@@ -3,6 +3,8 @@ package gitlab
 import (
 	"context"
 
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 )
@@ -14,6 +16,28 @@ type tokenFilter struct {
 }
 
 func (t tokenFilter) Matches(ctx context.Context, matchable serviceprovider.Matchable, token *api.SPIAccessToken) (bool, error) {
-	//TODO implement me
-	panic("implement me")
+	lg := log.FromContext(ctx, "matchableUrl", matchable.RepoUrl())
+
+	lg.Info("matching", "token", token.Name)
+	if token.Status.TokenMetadata == nil {
+		return false, nil
+	}
+
+	requiredScopes := serviceprovider.GetAllScopes(translateToGitlabScopes, matchable.Permissions())
+	hasScope := func(scope Scope) bool {
+		for _, s := range token.Status.TokenMetadata.Scopes {
+			if Scope(s).Implies(scope) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, s := range requiredScopes {
+		scope := Scope(s)
+		if !hasScope(scope) {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }

--- a/pkg/serviceprovider/gitlab/tokenfilter.go
+++ b/pkg/serviceprovider/gitlab/tokenfilter.go
@@ -1,0 +1,19 @@
+package gitlab
+
+import (
+	"context"
+
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
+)
+
+var _ serviceprovider.TokenFilter = (*tokenFilter)(nil)
+
+type tokenFilter struct {
+	metadataProvider *metadataProvider
+}
+
+func (t tokenFilter) Matches(ctx context.Context, matchable serviceprovider.Matchable, token *api.SPIAccessToken) (bool, error) {
+	//TODO implement me
+	panic("implement me")
+}

--- a/pkg/serviceprovider/gitlab/tokenfilter_test.go
+++ b/pkg/serviceprovider/gitlab/tokenfilter_test.go
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlab
+
+import (
+	"context"
+	"testing"
+
+	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatches(t *testing.T) {
+	tf := &tokenFilter{}
+
+	t.Run("match with no metadata", func(t *testing.T) {
+		res, err := tf.Matches(context.TODO(),
+			&api.SPIAccessTokenBinding{},
+			&api.SPIAccessToken{})
+		assert.NoError(t, err)
+		assert.False(t, res)
+	})
+
+	test := func(t *testing.T, binding *api.SPIAccessTokenBinding, token *api.SPIAccessToken, expectedMatch bool) {
+		res, err := tf.Matches(context.TODO(), binding, token)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedMatch, res)
+	}
+
+	t.Run("match by scopes", func(t *testing.T) {
+		binding := &api.SPIAccessTokenBinding{
+			Spec: api.SPIAccessTokenBindingSpec{
+				RepoUrl: "some-gitlab-repo",
+				Permissions: api.Permissions{
+					Required: []api.Permission{
+						{
+							Type: api.PermissionTypeWrite,
+							Area: api.PermissionAreaRepository,
+						},
+						{
+							Type: api.PermissionTypeRead,
+							Area: api.PermissionAreaRegistry,
+						},
+					},
+				},
+			},
+		}
+
+		nonMatchingToken := &api.SPIAccessToken{
+			Spec: api.SPIAccessTokenSpec{},
+			Status: api.SPIAccessTokenStatus{
+				TokenMetadata: &api.TokenMetadata{
+					Username:             "you",
+					UserId:               "42",
+					Scopes:               []string{string(ScopeWriteRepository)},
+					ServiceProviderState: []byte(""),
+				},
+			},
+		}
+
+		matchingToken := &api.SPIAccessToken{
+			Spec: api.SPIAccessTokenSpec{},
+			Status: api.SPIAccessTokenStatus{
+				TokenMetadata: &api.TokenMetadata{
+					Username:             "you",
+					UserId:               "42",
+					Scopes:               []string{string(ScopeWriteRepository), string(ScopeReadRegistry)},
+					ServiceProviderState: []byte(""),
+				},
+			},
+		}
+
+		matchingToken2 := &api.SPIAccessToken{
+			Spec: api.SPIAccessTokenSpec{},
+			Status: api.SPIAccessTokenStatus{
+				TokenMetadata: &api.TokenMetadata{
+					Username:             "you",
+					UserId:               "42",
+					Scopes:               []string{string(ScopeApi)},
+					ServiceProviderState: []byte(""),
+				},
+			},
+		}
+
+		test(t, binding, nonMatchingToken, false)
+		test(t, binding, matchingToken, true)
+		test(t, binding, matchingToken2, true)
+	})
+}

--- a/pkg/serviceproviders/known.go
+++ b/pkg/serviceproviders/known.go
@@ -17,6 +17,7 @@ package serviceproviders
 import (
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider/github"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider/gitlab"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider/hostcredentials"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider/quay"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
@@ -30,6 +31,7 @@ import (
 func KnownInitializers() map[config.ServiceProviderType]serviceprovider.Initializer {
 	return map[config.ServiceProviderType]serviceprovider.Initializer{
 		config.ServiceProviderTypeGitHub:          github.Initializer,
+		config.ServiceProviderTypeGitLab:          gitlab.Initializer,
 		config.ServiceProviderTypeQuay:            quay.Initializer,
 		config.ServiceProviderTypeHostCredentials: hostcredentials.Initializer,
 	}

--- a/pkg/spi-shared/config/config.go
+++ b/pkg/spi-shared/config/config.go
@@ -27,6 +27,7 @@ type ServiceProviderType string
 const (
 	ServiceProviderTypeGitHub          ServiceProviderType = "GitHub"
 	ServiceProviderTypeQuay            ServiceProviderType = "Quay"
+	ServiceProviderTypeGitLab          ServiceProviderType = "GitLab"
 	ServiceProviderTypeHostCredentials ServiceProviderType = "HostCredentials"
 
 	MetricsNamespace = "redhat_appstudio"

--- a/samples/binding-write-repo-gitlab.yaml
+++ b/samples/binding-write-repo-gitlab.yaml
@@ -1,0 +1,13 @@
+apiVersion: appstudio.redhat.com/v1beta1
+kind: SPIAccessTokenBinding
+metadata:
+  name: binding-read-repository
+spec:
+  permissions:
+    required:
+      - type: rw
+        area: repository
+  repoUrl: https://gitlab.com/xbaran4/test
+  secret:
+    name: token-read-repository
+    type: kubernetes.io/basic-auth

--- a/samples/binding-write-repo-gitlab.yaml
+++ b/samples/binding-write-repo-gitlab.yaml
@@ -7,7 +7,7 @@ spec:
     required:
       - type: rw
         area: repository
-  repoUrl: https://gitlab.com/xbaran4/test
+  repoUrl: https://gitlab.com/user/test
   secret:
     name: token-read-repository
     type: kubernetes.io/basic-auth


### PR DESCRIPTION
### What does this PR do?
Adds GitLab as a new supported service provider.

Some caveats:
-  `read_user` scope is needed by default to fetch user metadata with token
- ServiceProviderState, used to figure out to which repositories the token has access to, will be implemented in its own PR https://issues.redhat.com/browse/SVPI-255
- improved ServiceProvider probing will be implemented in it's own PR after support for multiple service provider user oauth configurations (https://issues.redhat.com/browse/SVPI-249) https://issues.redhat.com/browse/SVPI-256

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
Implements https://issues.redhat.com/browse/SVPI-234

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
Using OAuth flow: 
1. Deploy SPI with images: `quay.io/pbaran/spis:GITLAB` for oauth service and `quay.io/pbaran/spio:GITLAB` for operator
2. Create a private repository on some instance of GitLab (you can use https://gitlab.com)
3. Create an authorized app in your user settings, like in the picture below, where the redirect URI is your OAuth service URL + /gitlab/callback
![image](https://user-images.githubusercontent.com/73115616/197499144-6df538bf-9957-4f3a-b177-61f7788c1769.png)
4. Copy the client ID (a.k.a. application ID), Secret, and create a new GitLab entry in spi config like the example below:
```yaml
serviceProviders:
- type: GitHub
  clientId: "123"
  clientSecret: "42"
- type: GitLab
  clientId: "your client id..."
  clientSecret: "your client secret..."
  baseUrl: "https://gitlab.com"
```
5. Make sure that OAuth service and operator have loaded the new config.
6. Create a binding such as `samples/binding-write-repo-gitlab.yaml` where you replace the repoUrl with your own.
7. Copy OAuth URL from binding, login, and go through the OAuth flow.
8. SPIAccessToken should then look something like this: 
![image](https://user-images.githubusercontent.com/73115616/197501470-079e21ca-d8c1-4ae8-967d-318efe538718.png)

Using manual upload: The PR should work with GitLab's personal access tokens (PAT) by uploading the token on OAuth service: 
1. Same as 1. and 2. step in OAuth flow.
2. Create PAT in GitLab.
![image](https://user-images.githubusercontent.com/73115616/199254142-00752265-cbdf-4fcc-a6b7-8cfbc704c000.png)
3. Create binding same as in OAuth flow step 6.
4. Copy the token and upload it through token upload URL in binding.
5. SpiAccessToken should look the same as in OAuth flow step 8.