### PR TITLE
Add lifetime cleanup of FileContentRequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ are also applicable to the operator. The configmap for operator-specific configu
 | --token-ttl             | TOKENLIFETIMEDURATION       | 120h    | Access token lifetime in hours, minutes or seconds. Examples:  "3h",  "5h30m40s" etc.                                                                                            |
 | --binding-ttl           | BINDINGLIFETIMEDURATION     | 2h      | Access token binding lifetime in hours, minutes or seconds. Examples: "3h", "5h30m40s" etc.                                                                                      |
 | --access-check-ttl      | ACCESSCHECKLIFETIMEDURATION | 30m     | Access check lifetime in hours, minutes or seconds.                                                                                                                              |
+| --file-request-ttl      | FILEREQUESTLIFETIMEDURATION | 30m     | File content request lifetime in hours, minutes or seconds.                                                                                                                      |
 | --token-match-policy    | TOKENMATCHPOLICY            | any     | The policy to match the token against the binding. Options:  'any', 'exact'."`                                                                                                   |
 | --kcp-api-export-name   | APIEXPORTNAME               | spi     | SPI ApiExport name used in KCP environment to configure controller with virtual workspace.                                                                                       |
 | --deletion-grace-period | DELETIONGRACEPERIOD         | 2s      | The grace period between a condition for deleting a binding or token is satisfied and the token or binding actually being deleted.                                               |
@@ -422,5 +423,6 @@ At this stage, file request CR-s are intended to be single-used, so no further c
 or accessibility checks must be expected. A new CR instance should be used to re-request the content.
   
 Currently, the file retrievals are limited to GitHub repositories only, and files size up to 2 Megabytes.
+Default lifetime for file content requests is 30 min and can be changed via operator configuration parameter.
 
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -118,6 +118,12 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - spifilecontentrequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - spifilecontentrequests/status
   verbs:
   - get

--- a/controllers/spiaccesstokenbinding_controller.go
+++ b/controllers/spiaccesstokenbinding_controller.go
@@ -333,7 +333,7 @@ func (r *SPIAccessTokenBindingReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 func (r *SPIAccessTokenBindingReconciler) durationUntilNextReconcile(tb *api.SPIAccessTokenBinding) time.Duration {
-	return time.Until(tb.CreationTimestamp.Add(r.Configuration.AccessTokenBindingTtl).Add(r.Configuration.DeletionGracePeriod * time.Second))
+	return time.Until(tb.CreationTimestamp.Add(r.Configuration.AccessTokenBindingTtl).Add(r.Configuration.DeletionGracePeriod))
 }
 
 // getServiceProvider obtains the service provider instance according to the repository URL from the binding's spec.

--- a/controllers/spifilecontentrequest_controller.go
+++ b/controllers/spifilecontentrequest_controller.go
@@ -143,14 +143,13 @@ func (r *SPIFileContentRequestReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// cleanup file content requests by lifetime
-	requestLifetime := time.Since(request.CreationTimestamp.Time).Seconds()
-	if requestLifetime > r.Configuration.FileContentRequestTtl.Seconds() {
+	if time.Now().After(request.CreationTimestamp.Add(r.Configuration.FileContentRequestTtl)) {
 		err := r.K8sClient.Delete(ctx, &request)
 		if err != nil {
 			lg.Error(err, "failed to cleanup file content request on reaching the max lifetime", "error", err)
 			return ctrl.Result{}, fmt.Errorf("failed to cleanup file content request on reaching the max lifetime: %w", err)
 		}
-		lg.V(logs.DebugLevel).Info("file content request being cleaned up on reaching the max lifetime", "binding", request.ObjectMeta.Name, "requestLifetime", requestLifetime, "requestttl", r.Configuration.FileContentRequestTtl.Seconds())
+		lg.V(logs.DebugLevel).Info("file content request being cleaned up on reaching the max lifetime", "binding", request.ObjectMeta.Name, "requestLifetime", request.CreationTimestamp.String(), "requestTTL", r.Configuration.FileContentRequestTtl.String())
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/spifilecontentrequest_controller.go
+++ b/controllers/spifilecontentrequest_controller.go
@@ -275,7 +275,7 @@ type linkedFileRequestBindingsFinalizer struct {
 
 var _ finalizer.Finalizer = (*linkedFileRequestBindingsFinalizer)(nil)
 
-// Finalize removes the secret synced to the actual binging being deleted
+// Finalize removes the binding synced to the actual file content request which is being deleted
 func (f *linkedFileRequestBindingsFinalizer) Finalize(ctx context.Context, obj client.Object) (finalizer.Result, error) {
 	res := finalizer.Result{}
 	contentRequest, ok := obj.(*api.SPIFileContentRequest)

--- a/controllers/spifilecontentrequest_controller.go
+++ b/controllers/spifilecontentrequest_controller.go
@@ -46,7 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const linkedFileRequestBindingsFinalizerName = "spi.appstudio.redhat.com/file-linked-bindings" //nolint:gosec
+const linkedFileRequestBindingsFinalizerName = "spi.appstudio.redhat.com/file-linked-bindings"
 
 var linkedBindingErrorStateError = stderrors.New("linked binding is in error state")
 

--- a/controllers/starter.go
+++ b/controllers/starter.go
@@ -73,9 +73,10 @@ func SetupAllReconcilers(mgr controllerruntime.Manager, cfg *config.OperatorConf
 	}
 
 	if err = (&SPIFileContentRequestReconciler{
-		K8sClient:  mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		HttpClient: spf.HttpClient,
+		K8sClient:     mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		HttpClient:    spf.HttpClient,
+		Configuration: cfg,
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -186,6 +186,7 @@ var _ = BeforeSuite(func() {
 		AccessCheckTtl:        10 * time.Second,
 		AccessTokenTtl:        10 * time.Second,
 		AccessTokenBindingTtl: 10 * time.Second,
+		FileContentRequestTtl: 10 * time.Second,
 		DeletionGracePeriod:   10 * time.Second,
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ type OperatorCliArgs struct {
 	TokenLifetimeDuration       time.Duration `arg:"--token-ttl, env" default:"120h" help:"the time after which a token will be automatically deleted in hours, minutes or seconds. Examples:  \"3h\",  \"5h30m40s\" etc"`
 	BindingLifetimeDuration     time.Duration `arg:"--binding-ttl, env" default:"2h" help:"the time after which a token binding will be automatically deleted in hours, minutes or seconds. Examples: \"3h\", \"5h30m40s\" etc"`
 	AccessCheckLifetimeDuration time.Duration `arg:"--access-check-ttl, env" default:"30m" help:"the time after which SPIAccessCheck CR will be deleted by operator"`
+	FileRequestLifetimeDuration time.Duration `arg:"--file-request-ttl, env" default:"30m" help:"the time after which SPIFileContentRequest CR will be deleted by operator"`
 	TokenMatchPolicy            TokenPolicy   `arg:"--token-match-policy, env" default:"any" help:"The policy to match the token against the binding. Options:  'any', 'exact'."`
 	ApiExportName               string        `arg:"--kcp-api-export-name, env" default:"spi" help:"SPI ApiExport name used in KCP environment to configure controller with virtual workspace."`
 	DeletionGracePeriod         time.Duration `arg:"--deletion-grace-period, env" default:"2s" help:"The grace period between a condition for deleting a binding or token is satisfied and the token or binding actually being deleted."`
@@ -60,6 +61,9 @@ type OperatorConfiguration struct {
 	// AccessTokenBindingTtl is time after that AccessTokenBinding will be deleted.
 	AccessTokenBindingTtl time.Duration
 
+	//FileContentRequestTtl is time after that FileContentRequest will be deleted
+	FileContentRequestTtl time.Duration
+
 	// The policy to match the token against the binding
 	TokenMatchPolicy TokenPolicy
 
@@ -78,6 +82,7 @@ func LoadFrom(args *OperatorCliArgs) (OperatorConfiguration, error) {
 	ret.AccessCheckTtl = args.AccessCheckLifetimeDuration
 	ret.AccessTokenTtl = args.TokenLifetimeDuration
 	ret.AccessTokenBindingTtl = args.BindingLifetimeDuration
+	ret.FileContentRequestTtl = args.FileRequestLifetimeDuration
 	ret.TokenMatchPolicy = args.TokenMatchPolicy
 	ret.DeletionGracePeriod = args.DeletionGracePeriod
 


### PR DESCRIPTION
Signed-off-by: Max Shaposhnyk <mshaposh@redhat.com>

### What does this PR do?
 - Adds configurble lifetime cleanup of FileContentRequests (30 min by def)
 - Adds finalizer for cleaning up linked bindings if FileRequest removed manually or by t/out

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-241

### How to test this PR?
 - Build and deploy;
 
 **Flow A:**
 - Set lower file requests TTL for operator:
 ```
 - name: manager
   image: mshaposh/spio:latest
   command:
      - /operator
   args:
     - '--file-request-ttl=30s'
```
 - Create FileContentRequest from examples;
 - Wait FileContentRequest to be removed after TTL passed           
            
 **Flow B:**
 - Create FileContentRequest from examples;
 - Verify Binding is created
 - Remove FileContentRequest, verify binding deleted as well.
