### PR TITLE
Implement the service provider request metrics

### DIFF
--- a/controllers/starter.go
+++ b/controllers/starter.go
@@ -15,7 +15,10 @@
 package controllers
 
 import (
+	"fmt"
 	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"
 
@@ -36,6 +39,10 @@ func SetupAllReconcilers(mgr controllerruntime.Manager, cfg *config.OperatorConf
 	}
 
 	var err error
+
+	if err = serviceprovider.RegisterCommonMetrics(metrics.Registry); err != nil {
+		return fmt.Errorf("failed to register the metrics with k8s metrics registry: %w", err)
+	}
 
 	if err = (&SPIAccessTokenReconciler{
 		Client:                 mgr.GetClient(),

--- a/pkg/serviceprovider/github/queries.go
+++ b/pkg/serviceprovider/github/queries.go
@@ -19,23 +19,20 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"
+
 	"github.com/google/go-github/v45/github"
 	sperrors "github.com/redhat-appstudio/service-provider-integration-operator/pkg/errors"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+var metricsConfig = serviceprovider.CommonRequestMetricsConfig(config.ServiceProviderTypeGitHub)
+
 // AllAccessibleRepos lists all the repositories accessible by the current user
-type AllAccessibleRepos struct {
-	Viewer struct {
-		Repositories struct {
-			Nodes []struct {
-				ViewerPermission string `json:"viewerPermission"`
-				Url              string `json:"url"`
-			} `json:"nodes"`
-		} `json:"repositories"`
-	} `json:"viewer"`
-}
+type AllAccessibleRepos struct{}
 
 func (r *AllAccessibleRepos) FetchAll(ctx context.Context, githubClient *github.Client, accessToken string, state *TokenState) error {
 
@@ -48,6 +45,9 @@ func (r *AllAccessibleRepos) FetchAll(ctx context.Context, githubClient *github.
 		}
 	}
 	lg.V(logs.DebugLevel).Info("Fetching metadata request")
+
+	ctx = httptransport.ContextWithMetrics(ctx, metricsConfig)
+
 	// list all repositories for the authenticated user
 	opt := &github.RepositoryListOptions{}
 	opt.ListOptions.PerPage = 100

--- a/pkg/serviceprovider/metrics.go
+++ b/pkg/serviceprovider/metrics.go
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceprovider
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"
+)
+
+var (
+	// RequestCountMetric is the metric that collects the request counts for all service providers.
+	// We allow for the unbounded "hostname" label with the assumption that the real number of service providers will be
+	// limited to only a couple in practice.
+	//
+	// Note that while this metric may seem similar to the automatic _count of ResponseTimeMetric histogram, it is different
+	// because it counts the request attempts, which should also include requests for which it was not possible to obtain
+	// the response (which have the "failure" label set to true).
+	//
+	// Preferably, use the CommonRequestMetricsConfig function to use this metric and register it using the RegisterCommonMetrics
+	// function.
+	RequestCountMetric = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: config.MetricsNamespace,
+		Subsystem: config.MetricsSubsystem,
+		Name:      "service_provider_request_count_total",
+		Help:      "The request counts to service providers categorized by service provider type, hostname and HTTP method",
+	}, []string{"sp", "hostname", "method", "failure"})
+
+	// ResponseTimeMetric is the metric that collects the request response times for all service providers.
+	// We allow for the unbounded "hostname" label with the assumption that the real number of service providers will be
+	// limited to only a couple in practice.
+	//
+	// Preferably, use the CommonRequestMetricsConfig function to use this metric and register it using the RegisterCommonMetrics
+	// function.
+	ResponseTimeMetric = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: config.MetricsNamespace,
+		Subsystem: config.MetricsSubsystem,
+		Name:      "service_provider_response_time_seconds",
+		Help:      "The response time of service provider requests categorized by service provider hostname, HTTP method and status code",
+	}, []string{"sp", "hostname", "method", "status"})
+)
+
+// RegisterCommonMetrics registers the RequestCountMetric and ResponseTimeMetric with the provided registerer. This must be
+// called exactly once.
+func RegisterCommonMetrics(registerer prometheus.Registerer) error {
+	if err := registerer.Register(RequestCountMetric); err != nil {
+		return fmt.Errorf("failed to register service provider request count metric: %w", err)
+	}
+
+	if err := registerer.Register(ResponseTimeMetric); err != nil {
+		return fmt.Errorf("failed to register service provider response time metric: %w", err)
+	}
+
+	return nil
+}
+
+// CommonRequestMetricsConfig returns the metrics collection configuration for collecting the RequestCountMetric and
+// ResponseTimeMetric for the provided service provider type.
+//
+// The returned configuration can be used with httptransport.ContextWithMetrics to configure what metrics should be
+// collected in the http requests.
+func CommonRequestMetricsConfig(spType config.ServiceProviderType) *httptransport.HttpMetricCollectionConfig {
+	return &httptransport.HttpMetricCollectionConfig{
+		CounterPicker:            requestCountPicker(spType),
+		HistogramOrSummaryPicker: responseTimePicker(spType),
+	}
+}
+
+func requestCountPicker(spType config.ServiceProviderType) httptransport.HttpCounterMetricPickerFunc {
+	return func(request *http.Request, response *http.Response, err error) []prometheus.Counter {
+		failed := "false"
+		if err != nil || response == nil {
+			failed = "true"
+		}
+		return []prometheus.Counter{RequestCountMetric.WithLabelValues(string(spType), request.Host, request.Method, failed)}
+	}
+}
+
+func responseTimePicker(spType config.ServiceProviderType) httptransport.HttpHistogramOrSummaryMetricPickerFunc {
+	return func(request *http.Request, resp *http.Response, err error) []prometheus.Observer {
+		if resp == nil {
+			return nil
+		}
+		return []prometheus.Observer{ResponseTimeMetric.WithLabelValues(string(spType), request.Host, request.Method, strconv.Itoa(resp.StatusCode))}
+	}
+}

--- a/pkg/serviceprovider/metrics_test.go
+++ b/pkg/serviceprovider/metrics_test.go
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceprovider
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	prometheusTest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterMetrics(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	RequestCountMetric.Reset()
+	ResponseTimeMetric.Reset()
+
+	assert.NoError(t, RegisterCommonMetrics(registry))
+
+	RequestCountMetric.WithLabelValues("sp", "here.there", "GET", "false").Inc()
+	ResponseTimeMetric.WithLabelValues("sp", "here.there", "GET", "200").Observe(42)
+
+	count, err := prometheusTest.GatherAndCount(registry, "redhat_appstudio_spi_service_provider_request_count_total", "redhat_appstudio_spi_service_provider_response_time_seconds")
+	assert.Equal(t, 2, count)
+	assert.NoError(t, err)
+}
+
+func TestRequestMetricsConfig(t *testing.T) {
+	test := func(t *testing.T, r util.FakeRoundTrip, expectedLabels map[string]string) {
+		registry := prometheus.NewPedanticRegistry()
+		RequestCountMetric.Reset()
+		ResponseTimeMetric.Reset()
+
+		assert.NoError(t, RegisterCommonMetrics(registry))
+
+		cl := http.Client{
+			Transport: httptransport.HttpMetricCollectingRoundTripper{RoundTripper: r},
+		}
+
+		ctx := httptransport.ContextWithMetrics(context.Background(), CommonRequestMetricsConfig("test"))
+
+		req, err := http.NewRequestWithContext(ctx, "GET", "https://test.url/some/path", strings.NewReader(""))
+		assert.NoError(t, err)
+
+		_, _ = cl.Do(req)
+
+		mfs, err := registry.Gather()
+		assert.NoError(t, err)
+
+		for _, mf := range mfs {
+			for _, m := range mf.GetMetric() {
+				// check that all the metrics with some nonzero value have the expected labels
+				if m.Histogram != nil {
+					if m.Histogram.SampleCount == nil || *m.Histogram.SampleCount == 0 {
+						continue
+					}
+				} else if m.Counter != nil {
+					if m.Counter.Value == nil || *m.Counter.Value == 0 {
+						continue
+					}
+				} else {
+					assert.Fail(t, "only expecting histogram or counter metrics")
+				}
+
+				for _, lp := range m.Label {
+					assert.Equal(t, expectedLabels[*lp.Name], *lp.Value)
+				}
+			}
+		}
+	}
+
+	t.Run("collects successful requests", func(t *testing.T) {
+		test(t, func(r *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 42}, nil
+		}, map[string]string{"sp": "test", "hostname": "test.url", "method": "GET", "failure": "false", "status": "42"})
+
+	})
+
+	t.Run("collects unsuccessful requests", func(t *testing.T) {
+		test(t, func(r *http.Request) (*http.Response, error) {
+			return nil, errors.New("intentional request error")
+		}, map[string]string{"sp": "test", "hostname": "test.url", "method": "GET", "failure": "true"})
+	})
+}

--- a/pkg/serviceprovider/quay/metadataprovider.go
+++ b/pkg/serviceprovider/quay/metadataprovider.go
@@ -22,6 +22,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"
+
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +33,8 @@ import (
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 )
+
+var metricsConfig = serviceprovider.CommonRequestMetricsConfig(config.ServiceProviderTypeQuay)
 
 type metadataProvider struct {
 	tokenStorage     tokenstorage.TokenStorage
@@ -135,6 +140,8 @@ func (p metadataProvider) FetchRepo(ctx context.Context, repoUrl string, token *
 		lg.Info("no token data found")
 		return
 	}
+
+	ctx = httptransport.ContextWithMetrics(ctx, metricsConfig)
 
 	orgOrUser, repo, _ := splitToOrganizationAndRepositoryAndVersion(repoUrl)
 	if orgOrUser == "" || repo == "" {


### PR DESCRIPTION
### What does this PR do?
This adds the metrics to measure the number of requests that we're making to the service providers and their response times.
There are just 2 metrics `redhat_appstudio_spi_service_provider_request_count_total` and `redhat_appstudio_spi_service_provider_response_time_seconds_bucket` common for all service providers. The service provider type and hostname are provided as labels on those metrics.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-105

### How to test this PR?
1. Run SPI with `quay.io/lkrejci/service-provider-integration-operator:svpi-105` and `quay.io/lkrejci/service-provider-integration-oauth:svpi-105` docker images
2. configure the OAuth apps in Github and Quay
3. Create bindings to github and quay.
4. Provide token data to those bindings either by manual upload or through oauth flow.
5. `kubectl -n spi-system exec deployment/spi-controller-manager -c manager -t -- curl --silent localhost:8080/metrics | grep redhat` should list `redhat_appstudio_spi_service_provider_request_count_total` metrics and `redhat_appstudio_spi_service_provider_response_time_seconds_bucket` metrics.