### PR TITLE
Fixed incorrect replacement of commit id

### DIFF
--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -23,7 +23,7 @@ spec:
       value: |
         sed -i -e 's|\(https://github.com/redhat-appstudio/service-provider-integration-operator/config/kcp_openshift?ref=\)\(.*\)|\1{{ revision }}|' components/spi/base/kustomization.yaml;
         awk  -i inplace -v n=1 '/newTag:/ { if (++count == n) sub(/newTag:.*/, "newTag: {{ revision }}")} 1' components/spi/base/kustomization.yaml
-        sed -i -e 's|\(https://raw.githubusercontent.com/redhat-appstudio/service-provider-integration-operator/\)\(.*\)|\1{{ revision }}/hack/vault-init.sh|' hack/preview.sh;
+        sed -i -e 's|\(https://raw.githubusercontent.com/redhat-appstudio/service-provider-integration-operator/\)\(.*\)/hack/vault-init.sh|\1{{ revision }}/hack/vault-init.sh|' hack/preview.sh;
         sed -i -e 's|\(https://github.com/redhat-appstudio/service-provider-integration-operator/config/vault/openshift?ref=\)\(.*\)|\1{{ revision }}|' components/spi/vault/kustomization.yaml
   pipelineRef:
     name: docker-build


### PR DESCRIPTION
### What does this PR do?
current code makes an incorrect replacement. it removes ending `)`

### Screenshot/screencast of this PR
<img width="512" alt="Знімок екрана 2022-10-27 о 19 42 57" src="https://user-images.githubusercontent.com/1614429/198349835-bea3706a-9471-4008-bfb8-14d3443fed42.png">


### What issues does this PR fix or reference?
- https://issues.redhat.com/browse/SVPI-252
- https://github.com/redhat-appstudio/infra-deployments/pull/850#issuecomment-1293545530

### How to test this PR?
- git clone infra-deployment
- cd infra-deployment
- execute "sed" command