### PR TITLE
Remove the limitation for one service provider per type in the oauth service

### DIFF
--- a/controllers/spiaccesstoken_controller.go
+++ b/controllers/spiaccesstoken_controller.go
@@ -315,10 +315,7 @@ func (r *SPIAccessTokenReconciler) oAuthUrlFor(ctx context.Context, at *api.SPIA
 	if err != nil {
 		return "", fmt.Errorf("failed to determine the service provider from URL %s: %w", at.Spec.ServiceProviderUrl, err)
 	}
-	oauthBaseUrl := sp.GetOAuthEndpoint()
-	if len(oauthBaseUrl) == 0 {
-		return "", nil
-	}
+	oauthBaseUrl := r.Configuration.BaseUrl + "/oauth/authenticate"
 
 	kcpWorkspace := ""
 	if kcpWorkspaceName, hasKcpWorkspace := logicalcluster.ClusterFromContext(ctx); hasKcpWorkspace {

--- a/integration_tests/serviceprovider_mock.go
+++ b/integration_tests/serviceprovider_mock.go
@@ -32,7 +32,6 @@ type TestServiceProvider struct {
 	GetBaseUrlImpl            func() string
 	OAuthScopesForImpl        func(permissions *api.Permissions) []string
 	GetTypeImpl               func() api.ServiceProviderType
-	GetOauthEndpointImpl      func() string
 	CheckRepositoryAccessImpl func(context.Context, client.Client, *api.SPIAccessCheck) (*api.SPIAccessCheckStatus, error)
 	MapTokenImpl              func(context.Context, *api.SPIAccessTokenBinding, *api.SPIAccessToken, *api.Token) (serviceprovider.AccessTokenMapper, error)
 	ValidateImpl              func(context.Context, serviceprovider.Validated) (serviceprovider.ValidationResult, error)
@@ -82,13 +81,6 @@ func (t TestServiceProvider) GetType() api.ServiceProviderType {
 	return t.GetTypeImpl()
 }
 
-func (t TestServiceProvider) GetOAuthEndpoint() string {
-	if t.GetOauthEndpointImpl == nil {
-		return ""
-	}
-	return t.GetOauthEndpointImpl()
-}
-
 func (t TestServiceProvider) MapToken(ctx context.Context, binding *api.SPIAccessTokenBinding, token *api.SPIAccessToken, tokenData *api.Token) (serviceprovider.AccessTokenMapper, error) {
 	if t.MapTokenImpl == nil {
 		return serviceprovider.AccessTokenMapper{}, nil
@@ -110,7 +102,6 @@ func (t *TestServiceProvider) Reset() {
 	t.GetBaseUrlImpl = nil
 	t.OAuthScopesForImpl = nil
 	t.GetTypeImpl = nil
-	t.GetOauthEndpointImpl = nil
 	t.PersistMetadataImpl = nil
 	t.CheckRepositoryAccessImpl = nil
 	t.MapTokenImpl = nil

--- a/integration_tests/spiaccessbindingcontroller_test.go
+++ b/integration_tests/spiaccessbindingcontroller_test.go
@@ -91,9 +91,6 @@ var _ = Describe("Create binding", func() {
 	BeforeEach(func() {
 		ITest.TestServiceProvider.Reset()
 		createdBinding, createdToken = createStandardPair("create-test")
-		ITest.TestServiceProvider.GetOauthEndpointImpl = func() string {
-			return "test-provider://acme"
-		}
 		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
 
 		//dummy update to cause reconciliation

--- a/integration_tests/spiaccesstokencontroller_test.go
+++ b/integration_tests/spiaccesstokencontroller_test.go
@@ -96,9 +96,6 @@ var _ = Describe("Status", func() {
 		ITest.TestServiceProvider.Reset()
 		origBaseUrl = ITest.OperatorConfiguration.BaseUrl
 		ITest.OperatorConfiguration.BaseUrl = "https://initial.base.url"
-		ITest.TestServiceProvider.GetOauthEndpointImpl = func() string {
-			return ITest.OperatorConfiguration.BaseUrl + "/test/oauth"
-		}
 
 		createdToken = &api.SPIAccessToken{
 			ObjectMeta: metav1.ObjectMeta{

--- a/integration_tests/spifilecontentrequestcontroller_test.go
+++ b/integration_tests/spifilecontentrequestcontroller_test.go
@@ -30,9 +30,6 @@ var _ = Describe("Create without token data", func() {
 
 	BeforeEach(func() {
 		ITest.TestServiceProvider.Reset()
-		ITest.TestServiceProvider.GetOauthEndpointImpl = func() string {
-			return "test-provider://test"
-		}
 		createdRequest = &api.SPIFileContentRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "filerequest-",

--- a/oauth/common.go
+++ b/oauth/common.go
@@ -53,15 +53,9 @@ type commonController struct {
 	StateStorage     *StateStorage
 }
 
-// exchangeState is the state that we're sending out to the SP after checking the anonymous oauth state produced by
-// the operator as the initial OAuth URL. Notice that the state doesn't contain any sensitive information.
-type exchangeState struct {
-	oauthstate.OAuthInfo
-}
-
 // exchangeResult this the result of the OAuth exchange with all the data necessary to store the token into the storage
 type exchangeResult struct {
-	exchangeState
+	oauthstate.OAuthInfo
 	result              oauthFinishResult
 	token               *oauth2.Token
 	authorizationHeader string
@@ -72,19 +66,12 @@ func (c *commonController) redirectUrl() string {
 	return strings.TrimSuffix(c.BaseUrl, "/") + "/" + strings.ToLower(string(c.Config.ServiceProviderType)) + "/callback"
 }
 
-func (c *commonController) Authenticate(w http.ResponseWriter, r *http.Request) {
+func (c *commonController) Authenticate(w http.ResponseWriter, r *http.Request, state *oauthstate.OAuthInfo) {
 	ctx := r.Context()
 	lg := log.FromContext(ctx)
 
 	defer logs.TimeTrack(lg, time.Now(), "/authenticate")
 
-	stateString := r.FormValue("state")
-
-	state, err := oauthstate.ParseOAuthInfo(stateString)
-	if err != nil {
-		LogErrorAndWriteResponse(ctx, w, http.StatusBadRequest, "failed to decode the OAuth state", err)
-		return
-	}
 	ctx = infrastructure.InitKcpContext(ctx, state.TokenKcpWorkspace)
 	token, err := c.Authenticator.GetToken(ctx, r)
 	if err != nil {
@@ -113,16 +100,13 @@ func (c *commonController) Authenticate(w http.ResponseWriter, r *http.Request) 
 		LogErrorAndWriteResponse(ctx, w, http.StatusBadRequest, err.Error(), err)
 		return
 	}
-	keyedState := exchangeState{
-		OAuthInfo: state,
-	}
 
-	oauthCfg, oauthConfigErr := c.obtainOauthConfig(ctx, &state)
+	oauthCfg, oauthConfigErr := c.obtainOauthConfig(ctx, state)
 	if oauthConfigErr != nil {
 		LogErrorAndWriteResponse(ctx, w, http.StatusInternalServerError, "failed to create oauth confgiuration", oauthConfigErr)
 		return
 	}
-	oauthCfg.Scopes = keyedState.Scopes
+	oauthCfg.Scopes = state.Scopes
 
 	templateData := struct {
 		Url string
@@ -137,11 +121,11 @@ func (c *commonController) Authenticate(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-func (c *commonController) Callback(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func (c *commonController) Callback(ctx context.Context, w http.ResponseWriter, r *http.Request, state *oauthstate.OAuthInfo) {
 	lg := log.FromContext(ctx)
 	defer logs.TimeTrack(lg, time.Now(), "/callback")
 
-	exchange, err := c.finishOAuthExchange(ctx, r)
+	exchange, err := c.finishOAuthExchange(ctx, r, state)
 	if err != nil {
 		LogErrorAndWriteResponse(ctx, w, http.StatusBadRequest, "error in Service Provider token exchange", err)
 		return
@@ -168,20 +152,9 @@ func (c *commonController) Callback(ctx context.Context, w http.ResponseWriter, 
 
 // finishOAuthExchange implements the bulk of the Callback function. It returns the token, if obtained, the decoded
 // state from the oauth flow, if available, and the result of the authentication.
-func (c *commonController) finishOAuthExchange(ctx context.Context, r *http.Request) (exchangeResult, error) {
+func (c *commonController) finishOAuthExchange(ctx context.Context, r *http.Request, state *oauthstate.OAuthInfo) (exchangeResult, error) {
 	// TODO support the implicit flow here, too?
 
-	// check that the state is correct
-	stateString, err := c.StateStorage.UnveilState(ctx, r)
-	if err != nil {
-		return exchangeResult{result: oauthFinishError}, fmt.Errorf("failed to unveil token state: %w", err)
-	}
-
-	state := &exchangeState{}
-	err = oauthstate.ParseInto(stateString, state)
-	if err != nil {
-		return exchangeResult{result: oauthFinishError}, fmt.Errorf("failed to parse JWT state string: %w", err)
-	}
 	ctx = infrastructure.InitKcpContext(ctx, state.TokenKcpWorkspace)
 
 	k8sToken, err := c.Authenticator.GetToken(ctx, r)
@@ -191,7 +164,7 @@ func (c *commonController) finishOAuthExchange(ctx context.Context, r *http.Requ
 	ctx = WithAuthIntoContext(k8sToken, ctx)
 
 	// the state is ok, let's retrieve the token from the service provider
-	oauthCfg, oauthConfigErr := c.obtainOauthConfig(ctx, &state.OAuthInfo)
+	oauthCfg, oauthConfigErr := c.obtainOauthConfig(ctx, state)
 	if oauthConfigErr != nil {
 		return exchangeResult{result: oauthFinishError}, fmt.Errorf("failed to obtain oauth configuration: %w", oauthConfigErr)
 	}
@@ -206,7 +179,7 @@ func (c *commonController) finishOAuthExchange(ctx context.Context, r *http.Requ
 		return exchangeResult{result: oauthFinishError}, fmt.Errorf("failed to finish the OAuth exchange: %w", err)
 	}
 	return exchangeResult{
-		exchangeState:       *state,
+		OAuthInfo:           *state,
 		result:              oauthFinishAuthenticated,
 		token:               token,
 		authorizationHeader: k8sToken,
@@ -236,7 +209,7 @@ func (c *commonController) syncTokenData(ctx context.Context, exchange *exchange
 	return nil
 }
 
-func (c *commonController) checkIdentityHasAccess(ctx context.Context, state oauthstate.OAuthInfo) (bool, error) {
+func (c *commonController) checkIdentityHasAccess(ctx context.Context, state *oauthstate.OAuthInfo) (bool, error) {
 	review := v1.SelfSubjectAccessReview{
 		Spec: v1.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &v1.ResourceAttributes{

--- a/oauth/common_test.go
+++ b/oauth/common_test.go
@@ -44,12 +44,16 @@ import (
 
 var _ = Describe("Controller", func() {
 
-	prepareAnonymousState := func() string {
-		ret, err := oauthstate.Encode(&oauthstate.OAuthInfo{
+	getAnonymousState := func() *oauthstate.OAuthInfo {
+		return &oauthstate.OAuthInfo{
 			TokenName:      "mytoken",
 			TokenNamespace: IT.Namespace,
 			Scopes:         []string{"a", "b"},
-		})
+		}
+	}
+
+	prepareAnonymousState := func() string {
+		ret, err := oauthstate.Encode(getAnonymousState())
 		Expect(err).NotTo(HaveOccurred())
 		return ret
 	}
@@ -129,7 +133,7 @@ var _ = Describe("Controller", func() {
 		c := prepareController(g)
 
 		IT.SessionManager.LoadAndSave(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			c.Authenticate(w, r)
+			c.Authenticate(w, r, getAnonymousState())
 		})).ServeHTTP(res, req)
 
 		return c, spiState, res
@@ -145,7 +149,7 @@ var _ = Describe("Controller", func() {
 		c := prepareController(g)
 
 		IT.SessionManager.LoadAndSave(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			c.Authenticate(w, r)
+			c.Authenticate(w, r, getAnonymousState())
 		})).ServeHTTP(res, req)
 
 		return c, spiState, res
@@ -294,7 +298,7 @@ var _ = Describe("Controller", func() {
 				}
 
 				IT.SessionManager.LoadAndSave(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					controller.Callback(context.WithValue(r.Context(), oauth2.HTTPClient, ctxVal), w, r)
+					controller.Callback(context.WithValue(r.Context(), oauth2.HTTPClient, ctxVal), w, r, getAnonymousState())
 				})).ServeHTTP(res, req)
 
 				g.Expect(res.Code).To(Equal(http.StatusFound))
@@ -347,7 +351,7 @@ var _ = Describe("Controller", func() {
 				}
 
 				IT.SessionManager.LoadAndSave(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					controller.Callback(context.WithValue(r.Context(), oauth2.HTTPClient, ctxVal), w, r)
+					controller.Callback(context.WithValue(r.Context(), oauth2.HTTPClient, ctxVal), w, r, getAnonymousState())
 				})).ServeHTTP(res, req)
 
 				g.Expect(res.Code).To(Equal(http.StatusFound))

--- a/oauth/controller.go
+++ b/oauth/controller.go
@@ -19,6 +19,8 @@ import (
 	"html/template"
 	"net/http"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/oauthstate"
+
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"golang.org/x/oauth2"
@@ -34,10 +36,10 @@ var (
 type Controller interface {
 	// Authenticate handles the initial OAuth request. It should validate that the request is authenticated in Kubernetes
 	// compose the authenticated OAuth state and return a redirect to the service-provider OAuth endpoint with the state.
-	Authenticate(w http.ResponseWriter, r *http.Request)
+	Authenticate(w http.ResponseWriter, r *http.Request, state *oauthstate.OAuthInfo)
 
 	// Callback finishes the OAuth flow. It handles the final redirect from the OAuth flow of the service provider.
-	Callback(ctx context.Context, w http.ResponseWriter, r *http.Request)
+	Callback(ctx context.Context, w http.ResponseWriter, r *http.Request, state *oauthstate.OAuthInfo)
 }
 
 // oauthFinishResult is an enum listing the possible results of authentication during the commonController.finishOAuthExchange

--- a/oauth/oauth_router.go
+++ b/oauth/oauth_router.go
@@ -1,0 +1,116 @@
+package oauth
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/oauthstate"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var unknownServiceProviderError = errors.New("unknown service provider")
+
+type Router struct {
+	staticallyConfiguredControllers map[config.ServiceProviderType]map[string]Controller
+
+	// unused as of now, will be probably used when we handle
+	k8sClient    client.Client
+	stateStorage *StateStorage
+}
+
+type CallbackRoute struct {
+	router *Router
+}
+
+type AuthenticateRoute struct {
+	router *Router
+}
+
+type RouterConfiguration struct {
+	OAuthServiceConfiguration
+	Authenticator    *Authenticator
+	StateStorage     *StateStorage
+	K8sClient        client.Client
+	TokenStorage     tokenstorage.TokenStorage
+	RedirectTemplate *template.Template
+}
+
+func NewRouter(lg *logr.Logger, cfg RouterConfiguration) (*Router, error) {
+	controllersByTypeAndBaseUrl := map[config.ServiceProviderType]map[string]Controller{}
+	for _, sp := range cfg.ServiceProviders {
+		lg.Info("initializing service provider controller", "type", sp.ServiceProviderType, "url", sp.ServiceProviderBaseUrl)
+
+		controller, err := FromConfiguration(cfg.OAuthServiceConfiguration, sp, cfg.Authenticator, cfg.StateStorage, cfg.K8sClient, cfg.TokenStorage, cfg.RedirectTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize controller for SP type %s on base URL %s: %w", sp.ServiceProviderType, sp.ServiceProviderBaseUrl, err)
+		}
+
+		controllersByTypeAndBaseUrl[sp.ServiceProviderType][sp.ServiceProviderBaseUrl] = controller
+	}
+
+	return &Router{
+		staticallyConfiguredControllers: controllersByTypeAndBaseUrl,
+		k8sClient:                       cfg.K8sClient,
+		stateStorage:                    cfg.StateStorage,
+	}, nil
+}
+
+func (r *Router) Callback() *CallbackRoute {
+	return &CallbackRoute{router: r}
+}
+
+func (r *Router) Authenticate() *AuthenticateRoute {
+	return &AuthenticateRoute{router: r}
+}
+
+func (r *Router) findController(req *http.Request, veiled bool) (Controller, *oauthstate.OAuthInfo, error) {
+	var stateString string
+	var err error
+
+	if veiled {
+		stateString, err = r.stateStorage.UnveilState(req.Context(), req)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		stateString = req.FormValue("state")
+	}
+
+	state := &oauthstate.OAuthInfo{}
+	err = oauthstate.ParseInto(stateString, state)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	controller := r.staticallyConfiguredControllers[state.ServiceProviderType][state.ServiceProviderUrl]
+	if controller == nil {
+		return nil, nil, fmt.Errorf("%w: type '%s', base URL '%s'", unknownServiceProviderError, state.ServiceProviderType, state.ServiceProviderUrl)
+	}
+
+	return controller, state, nil
+}
+
+func (r *CallbackRoute) ServeHTTP(wrt http.ResponseWriter, req *http.Request) {
+	ctrl, state, err := r.router.findController(req, true)
+	if err != nil {
+		LogErrorAndWriteResponse(req.Context(), wrt, http.StatusBadRequest, "failed to find the service provider", err)
+		return
+	}
+
+	ctrl.Callback(req.Context(), wrt, req, state)
+}
+
+func (r *AuthenticateRoute) ServeHTTP(wrt http.ResponseWriter, req *http.Request) {
+	ctrl, state, err := r.router.findController(req, false)
+	if err != nil {
+		LogErrorAndWriteResponse(req.Context(), wrt, http.StatusBadRequest, "failed to find the service provider", err)
+		return
+	}
+
+	ctrl.Authenticate(wrt, req, state)
+}

--- a/pkg/serviceprovider/github/github.go
+++ b/pkg/serviceprovider/github/github.go
@@ -88,10 +88,6 @@ func newGithub(factory *serviceprovider.Factory, _ string) (serviceprovider.Serv
 
 var _ serviceprovider.ConstructorFunc = newGithub
 
-func (g *Github) GetOAuthEndpoint() string {
-	return g.Configuration.BaseUrl + "/github/authenticate"
-}
-
 func (g *Github) GetBaseUrl() string {
 	return "https://github.com"
 }

--- a/pkg/serviceprovider/gitlab/gitlab.go
+++ b/pkg/serviceprovider/gitlab/gitlab.go
@@ -264,10 +264,6 @@ func (g *Gitlab) parseGitlabRepoUrl(repoUrl string) (repoPath string, err error)
 	return strings.TrimPrefix(repoUrl, g.GetBaseUrl()), nil
 }
 
-func (g Gitlab) GetOAuthEndpoint() string {
-	return g.Configuration.BaseUrl + "/gitlab/authenticate"
-}
-
 func (g Gitlab) MapToken(_ context.Context, _ *api.SPIAccessTokenBinding, token *api.SPIAccessToken, tokenData *api.Token) (serviceprovider.AccessTokenMapper, error) {
 	return serviceprovider.DefaultMapToken(token, tokenData), nil
 }

--- a/pkg/serviceprovider/hostcredentials/hostcredentials.go
+++ b/pkg/serviceprovider/hostcredentials/hostcredentials.go
@@ -65,10 +65,6 @@ func newHostCredentialsProvider(factory *serviceprovider.Factory, repoUrl string
 
 var _ serviceprovider.ConstructorFunc = newHostCredentialsProvider
 
-func (g *HostCredentialsProvider) GetOAuthEndpoint() string {
-	return ""
-}
-
 func (g *HostCredentialsProvider) GetBaseUrl() string {
 	base, err := serviceprovider.GetHostWithScheme(g.repoUrl)
 	if err != nil {

--- a/pkg/serviceprovider/quay/quay.go
+++ b/pkg/serviceprovider/quay/quay.go
@@ -91,10 +91,6 @@ func newQuay(factory *serviceprovider.Factory, _ string) (serviceprovider.Servic
 
 var _ serviceprovider.ConstructorFunc = newQuay
 
-func (g *Quay) GetOAuthEndpoint() string {
-	return g.Configuration.BaseUrl + "/quay/authenticate"
-}
-
 func (g *Quay) GetBaseUrl() string {
 	return quayUrlBase
 }

--- a/pkg/serviceprovider/serviceprovider.go
+++ b/pkg/serviceprovider/serviceprovider.go
@@ -59,10 +59,6 @@ type ServiceProvider interface {
 
 	CheckRepositoryAccess(ctx context.Context, cl client.Client, accessCheck *api.SPIAccessCheck) (*api.SPIAccessCheckStatus, error)
 
-	// GetOAuthEndpoint returns the URL of the OAuth initiation. This must point to the SPI oauth service, NOT
-	//the service provider itself.
-	GetOAuthEndpoint() string
-
 	// MapToken creates an access token mapper for given binding and token using the service-provider specific data.
 	// The implementations can use the DefaultMapToken method if they don't use any custom logic.
 	MapToken(ctx context.Context, binding *api.SPIAccessTokenBinding, token *api.SPIAccessToken, tokenData *api.Token) (AccessTokenMapper, error)


### PR DESCRIPTION
### What does this PR do?
The URLs for initiating the OAuth flow needlessly contained the service provider type which made it impossible to have more than 1 service provider per type.

This PR removes that limitation

### What issues does this PR fix or reference?
none

### How to test this PR?
TBD