### PR TITLE
Added extra label app.kubernetes.io/part-of to Route

### DIFF
--- a/config/openshift/route.yaml
+++ b/config/openshift/route.yaml
@@ -1,6 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  labels:
+    app.kubernetes.io/part-of: service-provider-integration-operator
   name: spi-oauth
 spec:
   port:


### PR DESCRIPTION
### What does this PR do?
Since `Kustomize` didn't know about Routes , this pr add the common to all object label https://github.com/redhat-appstudio/service-provider-integration-operator/blob/0429885dde3e808d4bcc1bf4422aa7ea44d91b80/config/default/kustomization.yaml#L21

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
n/a


### How to test this PR?
n/a
