### PR TITLE
Additional file request status until binding is not provide the OAuth/upload URL-s

### DIFF
--- a/api/v1beta1/spifilecontentrequest_types.go
+++ b/api/v1beta1/spifilecontentrequest_types.go
@@ -51,6 +51,7 @@ type SPIFileContentRequestStatus struct {
 type SPIFileContentRequestPhase string
 
 const (
+	SPIFileContentRequestPhaseAwaitingBinding   SPIFileContentRequestPhase = "AwaitingBinding"
 	SPIFileContentRequestPhaseAwaitingTokenData SPIFileContentRequestPhase = "AwaitingTokenData"
 	SPIFileContentRequestPhaseDelivered         SPIFileContentRequestPhase = "Delivered"
 	SPIFileContentRequestPhaseError             SPIFileContentRequestPhase = "Error"

--- a/controllers/spifilecontentrequest_controller.go
+++ b/controllers/spifilecontentrequest_controller.go
@@ -187,7 +187,7 @@ func (r *SPIFileContentRequestReconciler) Reconcile(ctx context.Context, req ctr
 			}
 		}
 		//binding not yet fully ready to work with, let's try next time
-		if binding.Status.Phase == "" {
+		if binding.Status.Phase == "" || binding.Status.UploadUrl == "" {
 			return reconcile.Result{}, nil
 		}
 

--- a/controllers/spifilecontentrequest_controller.go
+++ b/controllers/spifilecontentrequest_controller.go
@@ -164,7 +164,7 @@ func (r *SPIFileContentRequestReconciler) Reconcile(ctx context.Context, req ctr
 			r.updateFileRequestStatusError(ctx, &request, serviceprovider.FileDownloadNotSupportedError{})
 			return ctrl.Result{}, serviceprovider.FileDownloadNotSupportedError{}
 		}
-		request.Status.Phase = api.SPIFileContentRequestPhaseAwaitingTokenData
+		request.Status.Phase = api.SPIFileContentRequestPhaseAwaitingBinding
 	} else if request.Status.Phase == api.SPIFileContentRequestPhaseDelivered {
 		// already injected, nothing to do
 		return ctrl.Result{}, nil
@@ -193,6 +193,7 @@ func (r *SPIFileContentRequestReconciler) Reconcile(ctx context.Context, req ctr
 
 		//binding not injected yet, let's just synchronize URL's and that's it
 		if binding.Status.Phase == api.SPIAccessTokenBindingPhaseAwaitingTokenData {
+			request.Status.Phase = api.SPIFileContentRequestPhaseAwaitingTokenData
 			request.Status.OAuthUrl = binding.Status.OAuthUrl
 			request.Status.TokenUploadUrl = binding.Status.UploadUrl
 		} else if binding.Status.Phase == api.SPIAccessTokenBindingPhaseInjected {

--- a/integration_tests/spifilecontentrequestcontroller_test.go
+++ b/integration_tests/spifilecontentrequestcontroller_test.go
@@ -63,18 +63,19 @@ var _ = Describe("Create without token data", func() {
 		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
 	})
 
-	It("have the status awaiting set", func() {
+	It("have the status awaiting binding set", func() {
+		Eventually(func(g Gomega) {
+			request := &api.SPIFileContentRequest{}
+			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), request)).To(Succeed())
+			g.Expect(request.Status.Phase == api.SPIFileContentRequestPhaseAwaitingBinding).To(BeTrue())
+		}).Should(Succeed())
+	})
+
+	It("have the upload and OAUth URLs set and status changed to awaiting token", func() {
 		Eventually(func(g Gomega) {
 			request := &api.SPIFileContentRequest{}
 			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), request)).To(Succeed())
 			g.Expect(request.Status.Phase == api.SPIFileContentRequestPhaseAwaitingTokenData).To(BeTrue())
-		}).Should(Succeed())
-	})
-
-	It("have the upload and OAUth URLs set", func() {
-		Eventually(func(g Gomega) {
-			request := &api.SPIFileContentRequest{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), request)).To(Succeed())
 			g.Expect(request.Status.TokenUploadUrl).NotTo(BeEmpty())
 			g.Expect(request.Status.OAuthUrl).NotTo(BeEmpty())
 		}).Should(Succeed())

--- a/samples/spiaccesstokenbinding-3.yaml
+++ b/samples/spiaccesstokenbinding-3.yaml
@@ -6,10 +6,8 @@ metadata:
 spec:
   permissions:
     required:
-      - type: rw
-        area: repository
       - type: r
-        area: user
+        area: repository
   repoUrl: https://github.com/spi-test-org-1/spi-org-test-repo-1
   secret:
     type: kubernetes.io/basic-auth

--- a/samples/spiaccesstokenbinding-3.yaml
+++ b/samples/spiaccesstokenbinding-3.yaml
@@ -6,8 +6,10 @@ metadata:
 spec:
   permissions:
     required:
-      - type: r
+      - type: rw
         area: repository
+      - type: r
+        area: user
   repoUrl: https://github.com/spi-test-org-1/spi-org-test-repo-1
   secret:
     type: kubernetes.io/basic-auth


### PR DESCRIPTION
### What does this PR do?
Sets additional file request status 'AwaitingBinding' until binding is not ready to provide the OAuth/upload URL-s

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-267

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
Just create file request (and watch it in separate window) which is not having token for that URL.
There should be short moment when there is no OAuth/upload URL-s and status is "AwaitingBinding"
It is hard to catch it. I have used something like:
```
while true
do
    kubectl get spifilecontentrequest test-file-content-request  -o json | jq .status
done
```