### PR TITLE
Test setup continued

### DIFF
--- a/controllers/spiaccesscheck_controller.go
+++ b/controllers/spiaccesscheck_controller.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
@@ -50,7 +52,7 @@ type SPIAccessCheckReconciler struct {
 
 func (r *SPIAccessCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lg := log.FromContext(ctx)
-	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessCheck")
+	defer logs.TimeTrackWithLazyLogger(func() logr.Logger { return lg }, time.Now(), "Reconcile SPIAccessCheck")
 
 	ac := api.SPIAccessCheck{}
 	if err := r.Get(ctx, req.NamespacedName, &ac); err != nil {

--- a/controllers/spiaccesstoken_controller.go
+++ b/controllers/spiaccesstoken_controller.go
@@ -238,8 +238,9 @@ func (r *SPIAccessTokenReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err := r.updateTokenStatusSuccess(ctx, &at); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update the status: %w", err)
 	}
-	lg.WithValues("phase_at_reconcile_end", at.Status.Phase).
-		V(logs.DebugLevel).Info("reconciliation finished successfully")
+
+	// this will get picked up by the time tracker
+	lg = lg.WithValues("phase_at_reconcile_end", at.Status.Phase)
 
 	return ctrl.Result{RequeueAfter: r.durationUntilNextReconcile(&at)}, nil
 }

--- a/controllers/spiaccesstokenbinding_controller.go
+++ b/controllers/spiaccesstokenbinding_controller.go
@@ -23,6 +23,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	kubevalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	"sigs.k8s.io/controller-runtime/pkg/finalizer"
@@ -146,7 +148,7 @@ func (r *SPIAccessTokenBindingReconciler) filteredBindingsAsRequests(ctx context
 
 func (r *SPIAccessTokenBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lg := log.FromContext(ctx)
-	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessTokenBinding")
+	defer logs.TimeTrackWithLazyLogger(func() logr.Logger { return lg }, time.Now(), "Reconcile SPIAccessTokenBinding")
 
 	binding := api.SPIAccessTokenBinding{}
 

--- a/controllers/spiaccesstokenbinding_controller.go
+++ b/controllers/spiaccesstokenbinding_controller.go
@@ -217,6 +217,7 @@ func (r *SPIAccessTokenBindingReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, fmt.Errorf("failed to validate the object: %w", err)
 	}
 	if len(validation.ScopeValidation) > 0 {
+		binding.Status.Phase = api.SPIAccessTokenBindingPhaseError
 		r.updateBindingStatusError(ctx, &binding, api.SPIAccessTokenBindingErrorReasonUnsupportedPermissions, NewAggregatedError(validation.ScopeValidation...))
 		return ctrl.Result{}, nil
 	}

--- a/controllers/spiaccesstokendataupdate_controller.go
+++ b/controllers/spiaccesstokendataupdate_controller.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -66,7 +68,7 @@ func (r *SPIAccessTokenDataUpdateReconciler) SetupWithManager(mgr ctrl.Manager) 
 // move the current state of the cluster closer to the desired state.
 func (r *SPIAccessTokenDataUpdateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lg := log.FromContext(ctx)
-	defer logs.TimeTrack(lg, time.Now(), "Reconcile SPIAccessTokenData")
+	defer logs.TimeTrackWithLazyLogger(func() logr.Logger { return lg }, time.Now(), "Reconcile SPIAccessTokenDataUpdate")
 
 	update := api.SPIAccessTokenDataUpdate{}
 

--- a/controllers/spifilecontentrequest_controller.go
+++ b/controllers/spifilecontentrequest_controller.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 
 	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
@@ -104,6 +106,8 @@ func (r *SPIFileContentRequestReconciler) SetupWithManager(mgr ctrl.Manager) err
 
 func (r *SPIFileContentRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lg := log.FromContext(ctx)
+
+	defer logs.TimeTrackWithLazyLogger(func() logr.Logger { return lg }, time.Now(), "Reconcile SPIFileContentRequest")
 
 	request := api.SPIFileContentRequest{}
 

--- a/integration_tests/spiaccessbindingcontroller_test.go
+++ b/integration_tests/spiaccessbindingcontroller_test.go
@@ -37,472 +37,609 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// a helper function to test that the controller eventually updates the object such that the linked token name
-// linked in the binding matches the provided criteria.
-func testTokenNameInStatus(createdBinding *api.SPIAccessTokenBinding, linkMatcher OmegaMatcher) {
-	Eventually(func(g Gomega) bool {
-		binding := &api.SPIAccessTokenBinding{}
-		g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-
-		cond := g.Expect(binding.Status.LinkedAccessTokenName).Should(linkMatcher) &&
-			g.Expect(binding.Labels[controllers.SPIAccessTokenLinkLabel]).Should(linkMatcher)
-
-		return cond
-	}).Should(BeTrue())
+func checkTokenNameInStatus(g Gomega, binding *api.SPIAccessTokenBinding, linkMatcher OmegaMatcher) {
+	g.Expect(binding.Status.LinkedAccessTokenName).Should(linkMatcher)
+	g.Expect(binding.Labels[controllers.SPIAccessTokenLinkLabel]).Should(linkMatcher)
 }
 
-func createStandardPair(namePrefix string) (*api.SPIAccessTokenBinding, *api.SPIAccessToken) {
+var _ = Describe("SPIAccessTokenBinding", func() {
+	Describe("Create binding", func() {
+		var createdBinding *api.SPIAccessTokenBinding
+		var createdToken *api.SPIAccessToken
 
-	var createdBinding *api.SPIAccessTokenBinding
-	var createdToken *api.SPIAccessToken
-
-	ITest.TestServiceProvider.Reset()
-	createdBinding = &api.SPIAccessTokenBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: namePrefix + "-binding-",
-			Namespace:    "default",
-		},
-		Spec: api.SPIAccessTokenBindingSpec{
-			RepoUrl: "test-provider://test",
-		},
-	}
-	Expect(ITest.Client.Create(ITest.Context, createdBinding)).To(Succeed())
-	Eventually(func(g Gomega) {
-		binding := &api.SPIAccessTokenBinding{}
-		g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-		g.Expect(binding.Status.LinkedAccessTokenName).NotTo(BeEmpty())
-
-		createdBinding = binding
-	}).Should(Succeed())
-	Eventually(func(g Gomega) {
-		createdToken = &api.SPIAccessToken{}
-		err := ITest.Client.Get(ITest.Context, client.ObjectKey{Name: createdBinding.Status.LinkedAccessTokenName, Namespace: createdBinding.Namespace}, createdToken)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(createdToken).NotTo(BeNil())
-		g.Expect(createdToken.Status.Phase).NotTo(BeEmpty())
-	}).Should(Succeed())
-	return createdBinding, createdToken
-}
-
-var _ = Describe("Create binding", func() {
-	var createdBinding *api.SPIAccessTokenBinding
-	var createdToken *api.SPIAccessToken
-
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		createdBinding, createdToken = createStandardPair("create-test")
-		ITest.TestServiceProvider.GetOauthEndpointImpl = func() string {
-			return "test-provider://acme"
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				Bindings: []*api.SPIAccessTokenBinding{
+					StandardTestBinding("create-test"),
+				},
+			},
+			Behavior: ITestBehavior{
+				AfterObjectsCreated: func(objects TestObjects) {
+					ITest.TestServiceProvider.GetOauthEndpointImpl = func() string {
+						return "test-provider://acme"
+					}
+					ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&objects.Tokens[0])
+				},
+			},
 		}
-		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
-
-		//dummy update to cause reconciliation
-		Eventually(func(g Gomega) {
-			binding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-			binding.Annotations = map[string]string{"foo": "bar"}
-			g.Expect(ITest.Client.Update(ITest.Context, binding)).To(Succeed())
-		}).Should(Succeed())
-	})
-
-	AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
-	})
-
-	It("registering the finalizers", func() {
-		Eventually(func(g Gomega) {
-			binding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-			g.Expect(binding.ObjectMeta.Finalizers).To(ContainElement("spi.appstudio.redhat.com/linked-secrets"))
-		}).Should(Succeed())
-	})
-
-	It("should link the token to the binding", func() {
-		testTokenNameInStatus(createdBinding, Equal(createdToken.Name))
-	})
-
-	It("should revert the updates to the linked token status", func() {
-		testTokenNameInStatus(createdBinding, Equal(createdToken.Name))
-
-		Eventually(func(g Gomega) error {
-			binding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-
-			binding.Status.LinkedAccessTokenName = "my random link name"
-			return ITest.Client.Status().Update(ITest.Context, binding)
-		}).Should(Succeed())
-
-		testTokenNameInStatus(createdBinding, Not(Or(BeEmpty(), Equal("my random link name"))))
-	})
-
-	It("should copy the OAuthUrl to the status and reflect the phase", func() {
-		Eventually(func(g Gomega) {
-			binding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-			g.Expect(binding.Status.OAuthUrl).NotTo(BeEmpty())
-			g.Expect(binding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseAwaitingTokenData))
-			g.Expect(binding.Status.ErrorReason).To(BeEmpty())
-			g.Expect(binding.Status.ErrorMessage).To(BeEmpty())
-		}).WithTimeout(10 * time.Second).Should(Succeed())
-	})
-
-	It("have the upload URL set", func() {
-		Eventually(func(g Gomega) {
-			binding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-			g.Expect(strings.HasSuffix(binding.Status.UploadUrl, "/token/"+createdToken.Namespace+"/"+createdToken.Name)).To(BeTrue())
-		}).Should(Succeed())
-	})
-})
-
-var _ = Describe("Update binding", func() {
-	var createdBinding *api.SPIAccessTokenBinding
-	var createdToken *api.SPIAccessToken
-
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		createdBinding, createdToken = createStandardPair("update-test")
-		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
-	})
-
-	AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
-	})
-
-	It("reverts updates to the linked token label", func() {
-		testTokenNameInStatus(createdBinding, Not(BeEmpty()))
-
-		Eventually(func(g Gomega) error {
-			binding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-			binding.Labels[controllers.SPIAccessTokenLinkLabel] = "my_random_link_name"
-			return ITest.Client.Update(ITest.Context, binding)
-		}).Should(Succeed())
-
-		testTokenNameInStatus(createdBinding, Not(Or(BeEmpty(), Equal("my_random_link_name"))))
-	})
-
-	It("reverts updates to the linked token in the status", func() {
-		testTokenNameInStatus(createdBinding, Not(BeEmpty()))
-
-		Eventually(func(g Gomega) error {
-			binding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-
-			binding.Status.LinkedAccessTokenName = "my random link name"
-			return ITest.Client.Status().Update(ITest.Context, binding)
-		}).Should(Succeed())
-
-		testTokenNameInStatus(createdBinding, Not(Or(BeEmpty(), Equal("my random link name"))))
-	})
-
-	When("lookup changes the token", func() {
-		var otherToken *api.SPIAccessToken
-
 		BeforeEach(func() {
-			otherToken = &api.SPIAccessToken{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "other-test-token",
-					Namespace:    "default",
-				},
-				Spec: api.SPIAccessTokenSpec{
-					ServiceProviderUrl: "test-provider://other",
-				},
-			}
-
-			Expect(ITest.Client.Create(ITest.Context, otherToken)).To(Succeed())
-
-			ITest.TestServiceProvider.LookupTokenImpl = func(ctx context.Context, c client.Client, binding *api.SPIAccessTokenBinding) (*api.SPIAccessToken, error) {
-				if strings.HasSuffix(binding.Spec.RepoUrl, "test") {
-					return createdToken, nil
-				} else if strings.HasSuffix(binding.Spec.RepoUrl, "other") {
-					return otherToken, nil
-				} else {
-					return nil, fmt.Errorf("request for invalid test token")
-				}
-			}
+			testSetup.BeforeEach(nil)
+			createdBinding = testSetup.InCluster.Bindings[0]
+			createdToken = testSetup.InCluster.Tokens[0]
 		})
 
 		AfterEach(func() {
-			ITest.TestServiceProvider.Reset()
+			testSetup.AfterEach()
 		})
 
-		It("changes the linked token, too", func() {
-			Eventually(func(g Gomega) {
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), createdBinding)).To(Succeed())
-
-				createdBinding.Spec.RepoUrl = "test-provider://other"
-				g.Expect(ITest.Client.Update(ITest.Context, createdBinding)).To(Succeed())
-			}).Should(Succeed())
-
-			Eventually(func(g Gomega) {
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), createdBinding)).To(Succeed())
-				g.Expect(createdBinding.Status.LinkedAccessTokenName).To(Equal(otherToken.Name))
-				g.Expect(createdBinding.Status.OAuthUrl).To(Equal(otherToken.Status.OAuthUrl))
-				g.Expect(createdBinding.Status.UploadUrl).To(Equal(otherToken.Status.UploadUrl))
-			}).Should(Succeed())
-		})
-	})
-})
-
-var _ = Describe("Delete binding", func() {
-	var createdBinding *api.SPIAccessTokenBinding
-	var createdToken *api.SPIAccessToken
-	var syncedSecret *corev1.Secret
-
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		createdBinding, createdToken = createStandardPair("delete-test")
-		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
-
-		err := ITest.TokenStorage.Store(ITest.Context, createdToken, &api.Token{
-			AccessToken: "token",
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		// now that the token is stored, we can simulate parsing its metadata from the SP
-		ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
-			Username:             "alois",
-			UserId:               "42",
-			Scopes:               []string{},
-			ServiceProviderState: []byte("state"),
+		It("registering the finalizers", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				binding := testSetup.InCluster.Bindings[0]
+				g.Expect(binding.ObjectMeta.Finalizers).To(ContainElement("spi.appstudio.redhat.com/linked-secrets"))
+			})
 		})
 
-		Eventually(func(g Gomega) {
-			By("waiting for the synced secret to appear")
-			currentBinding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), currentBinding)).To(Succeed())
-			g.Expect(currentBinding.Status.SyncedObjectRef.Name).NotTo(BeEmpty())
-			syncedSecret = &corev1.Secret{}
-			g.Expect(ITest.Client.Get(ITest.Context,
-				client.ObjectKey{Name: currentBinding.Status.SyncedObjectRef.Name, Namespace: currentBinding.Namespace},
-				syncedSecret)).To(Succeed())
-		}).WithTimeout(20 * time.Second).Should(Succeed())
+		It("should link the token to the binding", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				binding := testSetup.InCluster.Bindings[0]
+				checkTokenNameInStatus(g, binding, Equal(createdToken.Name))
+			})
+		})
 
-	})
+		It("should revert the updates to the linked token status", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				binding := testSetup.InCluster.Bindings[0]
+				checkTokenNameInStatus(g, binding, Equal(createdToken.Name))
+			})
 
-	AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
-	})
-
-	It("should delete the synced secret", func() {
-		Expect(ITest.Client.Delete(ITest.Context, createdBinding)).To(Succeed())
-		// and check that secret eventually disappeared
-		Eventually(func(g Gomega) {
-			err := ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(syncedSecret), &corev1.Secret{})
-			if errors.IsNotFound(err) {
-				return
-			}
-		}).Should(Succeed())
-	})
-
-	It("should delete binding by timeout", func() {
-		orig := ITest.OperatorConfiguration.AccessTokenBindingTtl
-		ITest.OperatorConfiguration.AccessTokenBindingTtl = 500 * time.Millisecond
-		defer func() {
-			ITest.OperatorConfiguration.AccessTokenBindingTtl = orig
-		}()
-
-		// and check that binding eventually disappeared
-		Eventually(func(g Gomega) {
-			err := ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), &api.SPIAccessToken{})
-			if errors.IsNotFound(err) {
-				return
-			} else {
-				//force reconciliation timeout is passed
+			Eventually(func(g Gomega) error {
 				binding := &api.SPIAccessTokenBinding{}
-				ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)
-				binding.Annotations = map[string]string{"foo": "bar"}
-				ITest.Client.Update(ITest.Context, binding)
-			}
-		}).Should(Succeed())
+				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
+
+				binding.Status.LinkedAccessTokenName = "my random link name"
+				return ITest.Client.Status().Update(ITest.Context, binding)
+			}).Should(Succeed())
+
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				binding := testSetup.InCluster.Bindings[0]
+				checkTokenNameInStatus(g, binding, Not(Or(BeEmpty(), Equal("my random link name"))))
+			})
+		})
+
+		It("should copy the OAuthUrl to the status and reflect the phase", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				binding := testSetup.InCluster.Bindings[0]
+				g.Expect(binding.Status.OAuthUrl).NotTo(BeEmpty())
+				g.Expect(binding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseAwaitingTokenData))
+				g.Expect(binding.Status.ErrorReason).To(BeEmpty())
+				g.Expect(binding.Status.ErrorMessage).To(BeEmpty())
+			})
+		})
+
+		It("have the upload URL set", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				binding := testSetup.InCluster.Bindings[0]
+				g.Expect(strings.HasSuffix(binding.Status.UploadUrl, "/token/"+createdToken.Namespace+"/"+createdToken.Name)).To(BeTrue())
+			})
+		})
 	})
-})
 
-var _ = Describe("Syncing", func() {
-	var createdBinding *api.SPIAccessTokenBinding
-	var createdToken *api.SPIAccessToken
+	Describe("Update binding", func() {
+		var createdBinding *api.SPIAccessTokenBinding
+		var createdToken *api.SPIAccessToken
 
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		createdBinding, createdToken = createStandardPair("sync-test")
-		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
-		createdBinding.Spec.Secret = api.SecretSpec{
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				Bindings: []*api.SPIAccessTokenBinding{
+					StandardTestBinding("update-test"),
+				},
+			},
+			Behavior: ITestBehavior{
+				AfterObjectsCreated: func(objects TestObjects) {
+					token := objects.Tokens[0]
+					ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&token)
+				},
+			},
+		}
+		BeforeEach(func() {
+			testSetup.BeforeEach(nil)
+			createdBinding = testSetup.InCluster.Bindings[0]
+			createdToken = testSetup.InCluster.Tokens[0]
+		})
+
+		AfterEach(func() {
+			testSetup.AfterEach()
+		})
+
+		It("reverts updates to the linked token label", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				checkTokenNameInStatus(g, testSetup.InCluster.Bindings[0], Not(BeEmpty()))
+			})
+
+			Eventually(func(g Gomega) error {
+				binding := &api.SPIAccessTokenBinding{}
+				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
+				binding.Labels[controllers.SPIAccessTokenLinkLabel] = "my_random_link_name"
+				return ITest.Client.Update(ITest.Context, binding)
+			}).Should(Succeed())
+
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				checkTokenNameInStatus(g, testSetup.InCluster.Bindings[0], Not(Or(BeEmpty(), Equal("my_random_link_name"))))
+			})
+		})
+
+		It("reverts updates to the linked token in the status", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				checkTokenNameInStatus(g, testSetup.InCluster.Bindings[0], Not(BeEmpty()))
+			})
+
+			Eventually(func(g Gomega) error {
+				binding := &api.SPIAccessTokenBinding{}
+				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
+
+				binding.Status.LinkedAccessTokenName = "my random link name"
+				return ITest.Client.Status().Update(ITest.Context, binding)
+			}).Should(Succeed())
+
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				checkTokenNameInStatus(g, testSetup.InCluster.Bindings[0], Not(Or(BeEmpty(), Equal("my random link name"))))
+			})
+		})
+
+		When("lookup changes the token", func() {
+			var otherToken *api.SPIAccessToken
+
+			BeforeEach(func() {
+				otherToken = &api.SPIAccessToken{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "other-test-token",
+						Namespace:    "default",
+					},
+					Spec: api.SPIAccessTokenSpec{
+						ServiceProviderUrl: "test-provider://other",
+					},
+				}
+
+				Expect(ITest.Client.Create(ITest.Context, otherToken)).To(Succeed())
+
+				ITest.TestServiceProvider.LookupTokenImpl = func(ctx context.Context, c client.Client, binding *api.SPIAccessTokenBinding) (*api.SPIAccessToken, error) {
+					if strings.HasSuffix(binding.Spec.RepoUrl, "test") {
+						return createdToken, nil
+					} else if strings.HasSuffix(binding.Spec.RepoUrl, "other") {
+						return otherToken, nil
+					} else {
+						return nil, fmt.Errorf("request for invalid test token")
+					}
+				}
+
+				testSetup.ReconcileWithCluster(nil)
+			})
+
+			It("changes the linked token, too", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), createdBinding)).To(Succeed())
+
+					createdBinding.Spec.RepoUrl = "test-provider://other"
+					g.Expect(ITest.Client.Update(ITest.Context, createdBinding)).To(Succeed())
+				}).Should(Succeed())
+
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					createdBinding = testSetup.InCluster.Bindings[0]
+					g.Expect(createdBinding.Status.LinkedAccessTokenName).To(Equal(otherToken.Name))
+					g.Expect(createdBinding.Status.OAuthUrl).To(Equal(otherToken.Status.OAuthUrl))
+					g.Expect(createdBinding.Status.UploadUrl).To(Equal(otherToken.Status.UploadUrl))
+				})
+			})
+		})
+	})
+
+	Describe("Delete binding", func() {
+		var createdBinding *api.SPIAccessTokenBinding
+		var syncedSecret *corev1.Secret
+
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				Bindings: []*api.SPIAccessTokenBinding{
+					StandardTestBinding("delete-test"),
+				},
+			},
+			Behavior: ITestBehavior{
+				AfterObjectsCreated: func(objects TestObjects) {
+					token := objects.Tokens[0]
+
+					ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&token)
+
+					err := ITest.TokenStorage.Store(ITest.Context, token, &api.Token{
+						AccessToken: "token",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					// now that the token is stored, we can simulate parsing its metadata from the SP
+					ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
+						Username:             "alois",
+						UserId:               "42",
+						Scopes:               []string{},
+						ServiceProviderState: []byte("state"),
+					})
+				},
+			},
+		}
+
+		BeforeEach(func() {
+			testSetup.BeforeEach(func(g Gomega) {
+				g.Expect(testSetup.InCluster.Bindings[0].Status.SyncedObjectRef.Name).NotTo(BeEmpty())
+			})
+			createdBinding = testSetup.InCluster.Bindings[0]
+
+			syncedSecret = &corev1.Secret{}
+			Expect(ITest.Client.Get(ITest.Context,
+				client.ObjectKey{Name: createdBinding.Status.SyncedObjectRef.Name, Namespace: createdBinding.Namespace},
+				syncedSecret)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			testSetup.AfterEach()
+		})
+
+		It("should delete the synced secret", func() {
+			Expect(ITest.Client.Delete(ITest.Context, createdBinding)).To(Succeed())
+
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				err := ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(syncedSecret), &corev1.Secret{})
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
+		})
+
+		It("should delete binding by timeout", func() {
+			ITest.OperatorConfiguration.AccessTokenBindingTtl = 500 * time.Millisecond
+
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				g.Expect(testSetup.InCluster.Bindings).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("Syncing", func() {
+		binding := StandardTestBinding("sync-test")
+		binding.Spec.Secret = api.SecretSpec{
 			Name: "binding-secret",
 			Type: corev1.SecretTypeBasicAuth,
 		}
-	})
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				Bindings: []*api.SPIAccessTokenBinding{
+					binding,
+				},
+			},
+			Behavior: ITestBehavior{
+				AfterObjectsCreated: func(objects TestObjects) {
+					ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&objects.Tokens[0])
+					ITest.TestServiceProvider.MapTokenImpl = func(_ context.Context, _ *api.SPIAccessTokenBinding, token *api.SPIAccessToken, data *api.Token) (serviceprovider.AccessTokenMapper, error) {
+						return serviceprovider.DefaultMapToken(token, data), nil
+					}
 
-	AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
-	})
+				},
+			},
+		}
 
-	When("token is ready", func() {
-		It("creates the secret with the data", func() {
-			By("checking there is no secret")
-			Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), createdBinding)).To(Succeed())
-			Expect(createdBinding.Status.SyncedObjectRef.Name).To(BeEmpty())
-
-			By("updating the token")
-			err := ITest.TokenStorage.Store(ITest.Context, createdToken, &api.Token{
-				AccessToken:  "access",
-				RefreshToken: "refresh",
-				TokenType:    "awesome",
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("waiting for the secret to be mentioned in the binding status")
-			Eventually(func(g Gomega) {
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), createdBinding)).To(Succeed())
-				g.Expect(createdBinding.Status.SyncedObjectRef.Name).To(Equal("binding-secret"))
-
-				secret := &corev1.Secret{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: createdBinding.Status.SyncedObjectRef.Name, Namespace: createdBinding.Namespace}, secret)).To(Succeed())
-				g.Expect(string(secret.Data["password"])).To(Equal("access"))
-			})
-		})
-
-		It("keeps the secret data valid", func() {
-			By("checking there is no secret")
-			Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), createdBinding)).To(Succeed())
-			Expect(createdBinding.Status.SyncedObjectRef.Name).To(BeEmpty())
-
-			By("updating the token")
-			err := ITest.TokenStorage.Store(ITest.Context, createdToken, &api.Token{
-				AccessToken:  "access",
-				RefreshToken: "refresh",
-				TokenType:    "awesome",
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("waiting for the secret to be mentioned in the binding status")
-			Eventually(func(g Gomega) {
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), createdBinding)).To(Succeed())
-				g.Expect(createdBinding.Status.SyncedObjectRef.Name).To(Equal("binding-secret"))
-
-				secret := &corev1.Secret{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: createdBinding.Status.SyncedObjectRef.Name, Namespace: createdBinding.Namespace}, secret)).To(Succeed())
-				g.Expect(string(secret.Data["password"])).To(Equal("access"))
-			})
-
-			By("changing secret data")
-			Eventually(func(g Gomega) {
-				secret := &corev1.Secret{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: createdBinding.Status.SyncedObjectRef.Name, Namespace: createdBinding.Namespace}, secret)).To(Succeed())
-				secret.Data["password"] = []byte("wrong")
-				g.Expect(ITest.Client.Update(ITest.Context, secret)).To(Succeed())
-			})
-
-			By("waiting for the secret data to be reverted back to the correct values")
-			Eventually(func(g Gomega) {
-				secret := &corev1.Secret{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: createdBinding.Status.SyncedObjectRef.Name, Namespace: createdBinding.Namespace}, secret)).To(Succeed())
-				g.Expect(string(secret.Data["password"])).To(Equal("access"))
-			})
-		})
-	})
-
-	When("token is not ready", func() {
-		It("doesn't create secret", func() {
-			Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), createdBinding)).To(Succeed())
-			Expect(createdBinding.Status.SyncedObjectRef.Name).To(BeEmpty())
-		})
-	})
-})
-
-var _ = Describe("Status updates", func() {
-	var createdToken *api.SPIAccessToken
-	var createdBinding *api.SPIAccessTokenBinding
-
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		createdBinding, createdToken = createStandardPair("status-updates-test")
-		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
-	})
-
-	AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
-	})
-
-	When("linked token is ready and secret not injected", func() {
 		BeforeEach(func() {
-			ITest.TestServiceProvider.LookupTokenImpl = nil
-			ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
-				Username:             "alois",
-				UserId:               "42",
-				Scopes:               []string{},
-				ServiceProviderState: []byte("state"),
-			})
-
-			err := ITest.TokenStorage.Store(ITest.Context, createdToken, &api.Token{
-				AccessToken: "access_token",
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			//force reconciliation
-			Eventually(func(g Gomega) {
-				token := &api.SPIAccessToken{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), token)).To(Succeed())
-				token.Annotations = map[string]string{"foo": "bar"}
-				g.Expect(ITest.Client.Update(ITest.Context, token)).To(Succeed())
-			}).Should(Succeed())
-
-			Eventually(func(g Gomega) {
-				currentToken := &api.SPIAccessToken{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), currentToken)).To(Succeed())
-				g.Expect(currentToken.Status.Phase).To(Equal(api.SPIAccessTokenPhaseReady))
-			}).Should(Succeed())
+			testSetup.BeforeEach(nil)
 		})
 
 		AfterEach(func() {
-			ITest.TestServiceProvider.LookupTokenImpl = nil
+			testSetup.AfterEach()
 		})
 
-		It("should end in error phase if linked token doesn't fit the requirements", func() {
-			// This happens when the OAuth flow gives fewer perms than we requested
-			// I.e. we link the token, the user goes through OAuth flow, but the token we get doesn't
-			// give us all the required permissions (which will manifest in it not being looked up during
-			// reconciliation for given binding).
+		When("token is ready", func() {
+			It("creates the secret with the data", func() {
+				By("checking there is no secret")
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					Expect(testSetup.InCluster.Bindings[0].Status.SyncedObjectRef.Name).To(BeEmpty())
+				})
 
-			// We have the token in the ready state... let's not look it up during token matching
-			ITest.TestServiceProvider.LookupTokenImpl = nil
+				By("updating the token")
+				err := ITest.TokenStorage.Store(ITest.Context, testSetup.InCluster.Tokens[0], &api.Token{
+					AccessToken:  "access",
+					RefreshToken: "refresh",
+					TokenType:    "awesome",
+				})
+				Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func(g Gomega) {
-				currentBinding := &api.SPIAccessTokenBinding{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), currentBinding)).To(Succeed())
-				g.Expect(currentBinding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseError))
-			}).Should(Succeed())
+				ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
+					Username: "test",
+					UserId:   "42",
+				})
+
+				By("waiting for the secret to be mentioned in the binding status")
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					binding := testSetup.InCluster.Bindings[0]
+					g.Expect(binding.Status.SyncedObjectRef.Name).To(Equal("binding-secret"))
+					secret := &corev1.Secret{}
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: binding.Status.SyncedObjectRef.Name, Namespace: binding.Namespace}, secret)).To(Succeed())
+					g.Expect(string(secret.Data["password"])).To(Equal("access"))
+				})
+			})
+
+			It("keeps the secret data valid", func() {
+				By("checking there is no secret")
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					Expect(testSetup.InCluster.Bindings[0].Status.SyncedObjectRef.Name).To(BeEmpty())
+				})
+
+				By("updating the token")
+				err := ITest.TokenStorage.Store(ITest.Context, testSetup.InCluster.Tokens[0], &api.Token{
+					AccessToken:  "access",
+					RefreshToken: "refresh",
+					TokenType:    "awesome",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
+					Username: "test",
+					UserId:   "42",
+				})
+
+				By("waiting for the secret to be mentioned in the binding status")
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					binding := testSetup.InCluster.Bindings[0]
+					g.Expect(binding.Status.SyncedObjectRef.Name).To(Equal("binding-secret"))
+					secret := &corev1.Secret{}
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: binding.Status.SyncedObjectRef.Name, Namespace: binding.Namespace}, secret)).To(Succeed())
+					g.Expect(string(secret.Data["password"])).To(Equal("access"))
+				})
+
+				By("changing secret data")
+				Eventually(func(g Gomega) {
+					binding := testSetup.InCluster.Bindings[0]
+					secret := &corev1.Secret{}
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: binding.Status.SyncedObjectRef.Name, Namespace: binding.Namespace}, secret)).To(Succeed())
+					secret.Data["password"] = []byte("wrong")
+					g.Expect(ITest.Client.Update(ITest.Context, secret)).To(Succeed())
+				})
+
+				By("waiting for the secret data to be reverted back to the correct values")
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					binding := testSetup.InCluster.Bindings[0]
+					secret := &corev1.Secret{}
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: binding.Status.SyncedObjectRef.Name, Namespace: binding.Namespace}, secret)).To(Succeed())
+					g.Expect(string(secret.Data["password"])).To(Equal("access"))
+				})
+			})
+		})
+
+		When("token is not ready", func() {
+			It("doesn't create secret", func() {
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					Expect(testSetup.InCluster.Bindings[0].Status.SyncedObjectRef.Name).To(BeEmpty())
+				})
+			})
 		})
 	})
 
-	When("linked token is not ready", func() {
-		// we need to use a dedicated binding for this test so that the outer levels can clean up.
-		// We will be linking this binding to a different token than the outer layers expect.
-		var testBinding *api.SPIAccessTokenBinding
-		var betterToken *api.SPIAccessToken
+	Describe("Status updates", func() {
+		var createdToken *api.SPIAccessToken
+		var createdBinding *api.SPIAccessTokenBinding
 
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				Bindings: []*api.SPIAccessTokenBinding{StandardTestBinding("status-updates-test")},
+			},
+			Behavior: ITestBehavior{
+				AfterObjectsCreated: func(objects TestObjects) {
+					ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&objects.Tokens[0])
+					ITest.TestServiceProvider.MapTokenImpl = func(_ context.Context, _ *api.SPIAccessTokenBinding, token *api.SPIAccessToken, data *api.Token) (serviceprovider.AccessTokenMapper, error) {
+						return serviceprovider.DefaultMapToken(token, data), nil
+					}
+				},
+			},
+		}
 		BeforeEach(func() {
-			betterToken = &api.SPIAccessToken{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "status-updates-better-",
-					Namespace:    "default",
-					Annotations: map[string]string{
-						"dummy": "true",
-					},
-				},
-				Spec: api.SPIAccessTokenSpec{
-					ServiceProviderUrl: "test-provider://",
-				},
-			}
+			testSetup.BeforeEach(nil)
+			createdToken = testSetup.InCluster.Tokens[0]
+			createdBinding = testSetup.InCluster.Bindings[0]
+		})
 
-			testBinding = &api.SPIAccessTokenBinding{
+		AfterEach(func() {
+			testSetup.AfterEach()
+		})
+
+		When("linked token is ready and secret not injected", func() {
+			BeforeEach(func() {
+				// We have the token in the ready state... let's not look it up during token matching
+				ITest.TestServiceProvider.LookupTokenImpl = nil
+
+				ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
+					Username:             "alois",
+					UserId:               "42",
+					Scopes:               []string{},
+					ServiceProviderState: []byte("state"),
+				})
+
+				err := ITest.TokenStorage.Store(ITest.Context, createdToken, &api.Token{
+					AccessToken: "access_token",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				//force reconciliation
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					g.Expect(testSetup.InCluster.Tokens[0].Status.Phase).To(Equal(api.SPIAccessTokenPhaseReady))
+				})
+			})
+
+			It("should end in error phase if linked token doesn't fit the requirements", func() {
+				// This happens when the OAuth flow gives fewer perms than we requested
+				// I.e. we link the token, the user goes through OAuth flow, but the token we get doesn't
+				// give us all the required permissions (which will manifest in it not being looked up during
+				// reconciliation for given binding).
+
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					g.Expect(testSetup.InCluster.Bindings[0].Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseError))
+				})
+			})
+		})
+
+		When("linked token is not ready", func() {
+			// we need to use a dedicated binding for this test so that the outer levels can clean up.
+			// We will be linking this binding to a different token than the outer layers expect.
+			var testBinding *api.SPIAccessTokenBinding
+			var betterToken *api.SPIAccessToken
+
+			BeforeEach(func() {
+				betterToken = &api.SPIAccessToken{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "status-updates-better-",
+						Namespace:    "default",
+						Annotations: map[string]string{
+							"dummy": "true",
+						},
+					},
+					Spec: api.SPIAccessTokenSpec{
+						ServiceProviderUrl: "test-provider://",
+					},
+				}
+
+				testBinding = &api.SPIAccessTokenBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "status-updates-",
+						Namespace:    "default",
+					},
+					Spec: api.SPIAccessTokenBindingSpec{
+						RepoUrl: "test-provider://acme/acme",
+						Secret: api.SecretSpec{
+							Type: corev1.SecretTypeBasicAuth,
+						},
+					},
+				}
+
+				Expect(ITest.Client.Create(ITest.Context, betterToken)).To(Succeed())
+				ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
+					Username:             "alois",
+					UserId:               "42",
+					Scopes:               []string{},
+					ServiceProviderState: []byte("state"),
+				})
+
+				err := ITest.TokenStorage.Store(ITest.Context, betterToken, &api.Token{
+					AccessToken: "access_token",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// we're trying to use the token defined by the outer layer first.
+				// This token is not ready, so we should be in a situation that should
+				// still enable swapping the token for a better fitting one.
+				ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
+
+				Expect(ITest.Client.Create(ITest.Context, testBinding)).To(Succeed())
+			})
+
+			It("replaces the linked token with a more precise lookup if available", func() {
+				// first, let's check that we're linked to the original token
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					binding := testSetup.InCluster.GetBinding(client.ObjectKeyFromObject(testBinding))
+					g.Expect(binding.Status.LinkedAccessTokenName).To(Equal(createdToken.Name))
+				})
+
+				// now start returning the better token from the lookup
+				ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&betterToken)
+
+				// and check that the binding switches to the better token
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					binding := testSetup.InCluster.GetBinding(client.ObjectKeyFromObject(testBinding))
+					g.Expect(binding.Status.LinkedAccessTokenName).To(Equal(betterToken.Name))
+				})
+			})
+		})
+
+		When("linked token data disappears after successful sync", func() {
+			var secret *corev1.Secret
+
+			BeforeEach(func() {
+				err := ITest.TokenStorage.Store(ITest.Context, createdToken, &api.Token{
+					AccessToken: "access_token",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
+					Username:             "alois",
+					UserId:               "42",
+					Scopes:               []string{},
+					ServiceProviderState: []byte("state"),
+				})
+
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					g.Expect(testSetup.InCluster.Tokens[0].Status.Phase).To(Equal(api.SPIAccessTokenPhaseReady))
+					g.Expect(testSetup.InCluster.Bindings[0].Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseInjected))
+					secret = &corev1.Secret{}
+					Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: testSetup.InCluster.Bindings[0].Status.SyncedObjectRef.Name, Namespace: "default"}, secret)).To(Succeed())
+				})
+			})
+
+			It("deletes the secret and flips back to awaiting phase", func() {
+				ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(nil)
+				Expect(ITest.TokenStorage.Delete(ITest.Context, createdToken)).To(Succeed())
+
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					binding := testSetup.InCluster.Bindings[0]
+					g.Expect(binding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseAwaitingTokenData))
+					g.Expect(binding.Status.SyncedObjectRef.Name).To(BeEmpty())
+
+					err := ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(secret), &corev1.Secret{})
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(errors.IsNotFound(err)).To(BeTrue())
+				})
+			})
+		})
+
+		When("binding requires invalid scopes", func() {
+			It("should flip to error state", func() {
+				ITest.TestServiceProvider.ValidateImpl = func(ctx context.Context, validated serviceprovider.Validated) (serviceprovider.ValidationResult, error) {
+					return serviceprovider.ValidationResult{
+						ScopeValidation: []error{stderrors.New("nope")},
+					}, nil
+				}
+
+				// now check that the binding flipped to the error state
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					binding := testSetup.InCluster.Bindings[0]
+					g.Expect(binding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseError))
+					g.Expect(binding.Status.ErrorReason).To(Equal(api.SPIAccessTokenBindingErrorReasonUnsupportedPermissions))
+				})
+			})
+		})
+
+		When("service provider url is invalid", func() {
+			It("should end in error phase and have an error message", func() {
+				createdBinding = &api.SPIAccessTokenBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "invalid-binding-",
+						Namespace:    "default",
+					},
+					Spec: api.SPIAccessTokenBindingSpec{
+						RepoUrl: "invalid://abc./name/repo",
+					},
+				}
+				ITest.HostCredsServiceProvider.GetBaseUrlImpl = func() string {
+					return "invalid://abc."
+				}
+				Expect(ITest.Client.Create(ITest.Context, createdBinding)).To(Succeed())
+
+				testSetup.ReconcileWithCluster(func(g Gomega) {
+					binding := testSetup.InCluster.GetBinding(client.ObjectKeyFromObject(createdBinding))
+					g.Expect(binding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseError))
+					g.Expect(binding.Status.ErrorMessage).To(Not(BeEmpty()))
+					g.Expect(binding.Status.ErrorReason).To(Equal(api.SPIAccessTokenBindingErrorReasonUnknownServiceProviderType))
+					g.Expect(binding.Status.LinkedAccessTokenName).To(BeEmpty())
+				})
+			})
+		})
+
+		When("linking fails", func() {
+			// This simulates a situation where the CRDs and the code is out-of-sync and any updates to the binding status
+			// fail.
+			origCRD := &apiexv1.CustomResourceDefinition{}
+			testBinding := &api.SPIAccessTokenBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "status-updates-",
+					GenerateName: "link-failing-",
 					Namespace:    "default",
 				},
 				Spec: api.SPIAccessTokenBindingSpec{
@@ -513,237 +650,50 @@ var _ = Describe("Status updates", func() {
 				},
 			}
 
-			Expect(ITest.Client.Create(ITest.Context, betterToken)).To(Succeed())
-			ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
-				Username:             "alois",
-				UserId:               "42",
-				Scopes:               []string{},
-				ServiceProviderState: []byte("state"),
+			BeforeEach(func() {
+				// we need to modify the cluster somehow so that updating the object status fails
+				// we will add a required property to the status schema so that the status update fails
+				Eventually(func(g Gomega) {
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "spiaccesstokenbindings.appstudio.redhat.com"}, origCRD)).To(Succeed())
+					updatedCRD := origCRD.DeepCopy()
+					status := updatedCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"]
+					status.Properties["__test"] = apiexv1.JSONSchemaProps{
+						Type: "string",
+					}
+					requiredStatusProps := status.Required
+					requiredStatusProps = append(requiredStatusProps, "__test")
+					status.Required = requiredStatusProps
+					updatedCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"] = status
+
+					g.Expect(ITest.Client.Update(ITest.Context, updatedCRD)).To(Succeed())
+				}).Should(Succeed())
+
+				ITest.TestServiceProvider.LookupTokenImpl = nil
+				Expect(ITest.Client.Create(ITest.Context, testBinding)).Should(Succeed())
 			})
 
-			err := ITest.TokenStorage.Store(ITest.Context, betterToken, &api.Token{
-				AccessToken: "access_token",
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			// we're trying to use the token defined by the outer layer first.
-			// This token is not ready, so we should be in a situation that should
-			// still enable swapping the token for a better fitting one.
-			ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
-			Expect(ITest.Client.Create(ITest.Context, testBinding)).To(Succeed())
-		})
-
-		AfterEach(func() {
-			ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&createdToken)
-		})
-
-		It("replaces the linked token with a more precise lookup if available", func() {
-			// first, let's check that we're linked to the original token
-			Eventually(func(g Gomega) {
-				currentBinding := &api.SPIAccessTokenBinding{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(testBinding), currentBinding)).To(Succeed())
-				g.Expect(currentBinding.Status.LinkedAccessTokenName).To(Equal(createdToken.Name))
-			}).Should(Succeed())
-
-			// now start returning the better token from the lookup
-			ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&betterToken)
-
-			// now simulate that betterToken got changed and has become a better match
-			// since we've set up the service provider above already, we only need to
-			// update the object in cluster to force reconciliation
-			Eventually(func(g Gomega) {
-				tkn := &api.SPIAccessToken{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(betterToken), tkn)).To(Succeed())
-				tkn.Annotations["dummy"] = "more_true"
-				g.Expect(ITest.Client.Update(ITest.Context, tkn)).To(Succeed())
-			}).Should(Succeed())
-
-			// and check that the binding switches to the better token
-			Eventually(func(g Gomega) {
-				currentBinding := &api.SPIAccessTokenBinding{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(testBinding), currentBinding)).To(Succeed())
-				g.Expect(currentBinding.Status.LinkedAccessTokenName).To(Equal(betterToken.Name))
-			}).Should(Succeed())
-		})
-	})
-
-	When("linked token data disappears after successful sync", func() {
-		var secret *corev1.Secret
-
-		BeforeEach(func() {
-			err := ITest.TokenStorage.Store(ITest.Context, createdToken, &api.Token{
-				AccessToken: "access_token",
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
-				Username:             "alois",
-				UserId:               "42",
-				Scopes:               []string{},
-				ServiceProviderState: []byte("state"),
+			AfterEach(func() {
+				// restore the CRD into its original state
+				Eventually(func(g Gomega) {
+					currentCRD := &apiexv1.CustomResourceDefinition{}
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(origCRD), currentCRD)).To(Succeed())
+					currentCRD.Spec = origCRD.Spec
+					g.Expect(ITest.Client.Update(ITest.Context, currentCRD)).To(Succeed())
+				}).Should(Succeed())
 			})
 
-			Eventually(func(g Gomega) {
-				currentToken := &api.SPIAccessToken{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdToken), currentToken)).To(Succeed())
-				g.Expect(currentToken.Status.Phase).To(Equal(api.SPIAccessTokenPhaseReady))
-			}).Should(Succeed())
-
-			currentBinding := &api.SPIAccessTokenBinding{}
-			Eventually(func(g Gomega) {
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), currentBinding)).To(Succeed())
-				g.Expect(currentBinding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseInjected))
-			}).Should(Succeed())
-
-			secret = &corev1.Secret{}
-			Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: currentBinding.Status.SyncedObjectRef.Name, Namespace: "default"}, secret)).To(Succeed())
-		})
-
-		It("deletes the secret and flips back to awaiting phase", func() {
-			ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(nil)
-			Expect(ITest.TokenStorage.Delete(ITest.Context, createdToken)).To(Succeed())
-
-			Eventually(func(g Gomega) {
-				currentBinding := &api.SPIAccessTokenBinding{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), currentBinding)).To(Succeed())
-				g.Expect(currentBinding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseAwaitingTokenData))
-				g.Expect(currentBinding.Status.SyncedObjectRef.Name).To(BeEmpty())
-
-				err := ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(secret), &corev1.Secret{})
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(errors.IsNotFound(err)).To(BeTrue())
-			}).Should(Succeed())
-		})
-	})
-
-	When("binding requires invalid scopes", func() {
-		It("should flip to error state", func() {
-			ITest.TestServiceProvider.ValidateImpl = func(ctx context.Context, validated serviceprovider.Validated) (serviceprovider.ValidationResult, error) {
-				return serviceprovider.ValidationResult{
-					ScopeValidation: []error{stderrors.New("nope")},
-				}, nil
-			}
-
-			// update the binding to force reconciliation after we change the impl of the validation
-			Eventually(func(g Gomega) {
-				currentBinding := &api.SPIAccessTokenBinding{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), currentBinding)).To(Succeed())
-				currentBinding.Annotations = map[string]string{"just-an-annotation": "to force reconciliation"}
-				g.Expect(ITest.Client.Update(ITest.Context, currentBinding)).To(Succeed())
-			}).Should(Succeed())
-
-			// now check that the binding flipped to the error state
-			Eventually(func(g Gomega) {
-				currentBinding := &api.SPIAccessTokenBinding{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), currentBinding)).To(Succeed())
-
-				g.Expect(currentBinding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseError))
-				g.Expect(currentBinding.Status.ErrorReason).To(Equal(api.SPIAccessTokenBindingErrorReasonUnsupportedPermissions))
+			It("should not create a token", func() {
+				Consistently(func(g Gomega) {
+					tokens := &api.SPIAccessTokenList{}
+					g.Expect(ITest.Client.List(ITest.Context, tokens)).Should(Succeed())
+					// there should only be 1 token (the one created in the outer level). The change to the CRD makes every
+					// attempt to create a new token and link it fail and clean up the freshly created token.
+					// Because of the errors, we clean up but are left in a perpetual cycle of trying to create the linked
+					// token and failing to link it and thus the new tokens are continuously appearing and disappearing.
+					// Let's just check here that their number is not growing too much too quickly by this crude measure.
+					g.Expect(len(tokens.Items)).To(BeNumerically("<", 5))
+				}, "3s").Should(Succeed())
 			})
-		})
-	})
-
-	When("service provider url is invalid", func() {
-		It("should end in error phase and have an error message", func() {
-			createdBinding = &api.SPIAccessTokenBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "invalid-binding-",
-					Namespace:    "default",
-				},
-				Spec: api.SPIAccessTokenBindingSpec{
-					RepoUrl: "invalid://abc./name/repo",
-				},
-			}
-			ITest.HostCredsServiceProvider.GetBaseUrlImpl = func() string {
-				return "invalid://abc."
-			}
-			Expect(ITest.Client.Create(ITest.Context, createdBinding)).To(Succeed())
-
-			//dummy update to cause reconciliation
-			Eventually(func(g Gomega) {
-				binding := &api.SPIAccessTokenBinding{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-				binding.Annotations = map[string]string{"foo": "bar"}
-				g.Expect(ITest.Client.Update(ITest.Context, binding)).To(Succeed())
-			}).Should(Succeed())
-
-			Eventually(func(g Gomega) {
-				binding := &api.SPIAccessTokenBinding{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), binding)).To(Succeed())
-				g.Expect(binding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseError))
-				g.Expect(binding.Status.ErrorMessage).To(Not(BeEmpty()))
-				g.Expect(binding.Status.ErrorReason).To(Equal(api.SPIAccessTokenBindingErrorReasonUnknownServiceProviderType))
-				g.Expect(binding.Status.LinkedAccessTokenName).To(BeEmpty())
-			}).Should(Succeed())
-			ITest.HostCredsServiceProvider.Reset()
-		})
-	})
-
-	When("linking fails", func() {
-		// This simulates a situation where the CRDs and the code is out-of-sync and any updates to the binding status
-		// fail.
-		origCRD := &apiexv1.CustomResourceDefinition{}
-		testBinding := &api.SPIAccessTokenBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "link-failing-",
-				Namespace:    "default",
-			},
-			Spec: api.SPIAccessTokenBindingSpec{
-				RepoUrl: "test-provider://acme/acme",
-				Secret: api.SecretSpec{
-					Type: corev1.SecretTypeBasicAuth,
-				},
-			},
-		}
-
-		BeforeEach(func() {
-			// we need to modify the cluster somehow so that updating the object status fails
-			// we will add a required property to the status schema so that the status update fails
-			Eventually(func(g Gomega) {
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: "spiaccesstokenbindings.appstudio.redhat.com"}, origCRD)).To(Succeed())
-				updatedCRD := origCRD.DeepCopy()
-				status := updatedCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"]
-				status.Properties["__test"] = apiexv1.JSONSchemaProps{
-					Type: "string",
-				}
-				requiredStatusProps := status.Required
-				requiredStatusProps = append(requiredStatusProps, "__test")
-				status.Required = requiredStatusProps
-				updatedCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["status"] = status
-
-				g.Expect(ITest.Client.Update(ITest.Context, updatedCRD)).To(Succeed())
-			}).Should(Succeed())
-
-			ITest.TestServiceProvider.LookupTokenImpl = nil
-			Expect(ITest.Client.Create(ITest.Context, testBinding)).Should(Succeed())
-		})
-
-		AfterEach(func() {
-			// restore the CRD into its original state
-			Eventually(func(g Gomega) {
-				currentCRD := &apiexv1.CustomResourceDefinition{}
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(origCRD), currentCRD)).To(Succeed())
-				currentCRD.Spec = origCRD.Spec
-				g.Expect(ITest.Client.Update(ITest.Context, currentCRD)).To(Succeed())
-			}).Should(Succeed())
-		})
-
-		It("should not create a token", func() {
-			Eventually(func(g Gomega) {
-				g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdBinding), createdBinding)).To(Succeed())
-				g.Expect(createdBinding.Status.LinkedAccessTokenName).To(Equal(createdToken.Name))
-			}).Should(Succeed())
-
-			Consistently(func(g Gomega) {
-				tokens := &api.SPIAccessTokenList{}
-				g.Expect(ITest.Client.List(ITest.Context, tokens)).Should(Succeed())
-				// there should only be 1 token (the one created in the outer level). The change to the CRD makes every
-				// attempt to create a new token and link it fail and clean up the freshly created token.
-				// Because of the errors, we clean up but are left in a perpetual cycle of trying to create the linked
-				// token and failing to link it and thus the new tokens are continuously appearing and disappearing.
-				// Let's just check here that their number is not growing too much too quickly by this crude measure.
-				g.Expect(len(tokens.Items)).To(BeNumerically("<", 5))
-			}, "10s").Should(Succeed())
 		})
 	})
 })

--- a/integration_tests/spiaccesstokencontroller_test.go
+++ b/integration_tests/spiaccesstokencontroller_test.go
@@ -401,6 +401,10 @@ var _ = Describe("SPIAccessToken", func() {
 				createdToken = testSetup.InCluster.Tokens[0]
 			})
 
+			AfterEach(func() {
+				testSetup.AfterEach()
+			})
+
 			It("defaults to AwaitingTokenData with common type", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(createdToken.Status.Phase).To(Equal(api.SPIAccessTokenPhaseAwaitingTokenData))

--- a/integration_tests/spifilecontentrequestcontroller_test.go
+++ b/integration_tests/spifilecontentrequestcontroller_test.go
@@ -24,8 +24,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,317 +33,212 @@ func (f testCapability) DownloadFile(context.Context, string, string, string, *a
 	return "abcdefg", nil
 }
 
-var _ = Describe("Create without token data", func() {
-	var createdRequest *api.SPIFileContentRequest
+var _ = Describe("SPIFileContentRequest", func() {
 
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		ITest.TestServiceProvider.DownloadFileCapability = func() serviceprovider.DownloadFileCapability { return testCapability{} }
-		ITest.TestServiceProvider.GetOauthEndpointImpl = func() string {
-			return "test-provider://test"
-		}
-		createdRequest = &api.SPIFileContentRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "filerequest-",
-				Namespace:    "default",
+	Describe("Create without token data", func() {
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				FileContentRequests: []*api.SPIFileContentRequest{StandardFileRequest("create-wo-token-data")},
 			},
-			Spec: api.SPIFileContentRequestSpec{
-				RepoUrl:  "test-provider://test",
-				FilePath: "foo/bar.txt",
-			},
-		}
-		Expect(ITest.Client.Create(ITest.Context, createdRequest)).To(Succeed())
-	})
-
-	var _ = AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIFileContentRequest{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
-	})
-
-	It("have the status awaiting binding set", func() {
-		Eventually(func(g Gomega) {
-			request := &api.SPIFileContentRequest{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), request)).To(Succeed())
-			g.Expect(request.Status.Phase == api.SPIFileContentRequestPhaseAwaitingBinding).To(BeTrue())
-		}).Should(Succeed())
-	})
-
-	It("have the upload and OAUth URLs set and status changed to awaiting token", func() {
-		Eventually(func(g Gomega) {
-			request := &api.SPIFileContentRequest{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), request)).To(Succeed())
-			g.Expect(request.Status.Phase == api.SPIFileContentRequestPhaseAwaitingTokenData).To(BeTrue())
-			g.Expect(request.Status.TokenUploadUrl).NotTo(BeEmpty())
-			g.Expect(request.Status.OAuthUrl).NotTo(BeEmpty())
-		}).Should(Succeed())
-	})
-})
-var _ = Describe("With binding is in error", func() {
-	var createdRequest *api.SPIFileContentRequest
-
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		ITest.TestServiceProvider.DownloadFileCapability = func() serviceprovider.DownloadFileCapability { return testCapability{} }
-		createdRequest = &api.SPIFileContentRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "filerequest-",
-				Namespace:    "default",
-			},
-			Spec: api.SPIFileContentRequestSpec{
-				RepoUrl:  "test-provider://test",
-				FilePath: "foo/bar.txt",
-			},
-		}
-		Expect(ITest.Client.Create(ITest.Context, createdRequest)).To(Succeed())
-		// re-read to fill other fields
-		Eventually(func(g Gomega) {
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), createdRequest)).To(Succeed())
-			g.Expect(createdRequest.Status.LinkedBindingName).NotTo(BeEmpty())
-		}).Should(Succeed())
-
-		binding := &api.SPIAccessTokenBinding{}
-		Eventually(func(g Gomega) {
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: createdRequest.Status.LinkedBindingName, Namespace: createdRequest.Namespace}, binding)).To(Succeed())
-			g.Expect(binding.Status.LinkedAccessTokenName).NotTo(BeEmpty())
-		}).Should(Succeed())
-
-		token := &api.SPIAccessToken{}
-		Eventually(func(g Gomega) {
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: binding.Status.LinkedAccessTokenName, Namespace: binding.Namespace}, token)).To(Succeed())
-		}).Should(Succeed())
-
-		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&token)
-		ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
-			Username:             "alois",
-			UserId:               "42",
-			Scopes:               []string{},
-			ServiceProviderState: []byte("state"),
-		})
-		err := ITest.TokenStorage.Store(ITest.Context, token, &api.Token{
-			AccessToken: "token",
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		//to fail binding
-		ITest.TestServiceProvider.LookupTokenImpl = nil
-
-		// update the binding to force reconciliation
-		Eventually(func(g Gomega) {
-			currentBinding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(binding), currentBinding)).To(Succeed())
-			currentBinding.Annotations = map[string]string{"just-an-annotation": "to force reconciliation"}
-			g.Expect(ITest.Client.Update(ITest.Context, currentBinding)).To(Succeed())
-		}).Should(Succeed())
-
-		// wait for error state
-		Eventually(func(g Gomega) {
-			currentBinding := &api.SPIAccessTokenBinding{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(binding), currentBinding)).To(Succeed())
-			g.Expect(currentBinding.Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseError))
-		}).Should(Succeed())
-	})
-
-	var _ = AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIFileContentRequest{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
-	})
-
-	It("sets request into error too", func() {
-		Eventually(func(g Gomega) {
-			request := &api.SPIFileContentRequest{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), request)).To(Succeed())
-			g.Expect(request.Status.Phase).To(Equal(api.SPIFileContentRequestPhaseError))
-			g.Expect(request.Status.ErrorMessage).To(HavePrefix("linked binding is in error state"))
-		}).Should(Succeed())
-	})
-
-})
-
-var _ = Describe("Request is removed", func() {
-	var createdRequest *api.SPIFileContentRequest
-
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		ITest.TestServiceProvider.DownloadFileCapability = func() serviceprovider.DownloadFileCapability { return testCapability{} }
-		createdRequest = &api.SPIFileContentRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "filerequest-",
-				Namespace:    "default",
-			},
-			Spec: api.SPIFileContentRequestSpec{
-				RepoUrl:  "test-provider://test",
-				FilePath: "foo/bar.txt",
-			},
-		}
-		Expect(ITest.Client.Create(ITest.Context, createdRequest)).To(Succeed())
-		// re-read to fill other fields
-		Eventually(func(g Gomega) {
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), createdRequest)).To(Succeed())
-			g.Expect(createdRequest.Status.LinkedBindingName).NotTo(BeEmpty())
-		}).Should(Succeed())
-	})
-
-	var _ = AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIFileContentRequest{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
-	})
-
-	It("it removes the binding, too", func() {
-		Expect(ITest.Client.Delete(ITest.Context, createdRequest)).To(Succeed())
-		binding := &api.SPIAccessTokenBinding{}
-		Eventually(func(g Gomega) {
-			err := ITest.Client.Get(ITest.Context, client.ObjectKey{Name: createdRequest.Status.LinkedBindingName, Namespace: createdRequest.Namespace}, binding)
-			g.Expect(errors.IsNotFound(err)).To(BeTrue())
-		}).Should(Succeed())
-	})
-
-	It("should delete request by timeout", func() {
-		orig := ITest.OperatorConfiguration.FileContentRequestTtl
-		ITest.OperatorConfiguration.FileContentRequestTtl = 500 * time.Millisecond
-		defer func() {
-			ITest.OperatorConfiguration.FileContentRequestTtl = orig
-		}()
-
-		// and check that request eventually disappeared
-		Eventually(func(g Gomega) {
-			err := ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), &api.SPIAccessToken{})
-			if errors.IsNotFound(err) {
-				return
-			} else {
-				//force reconciliation timeout is passed
-				request := &api.SPIFileContentRequest{}
-				ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), request)
-				request.Annotations = map[string]string{"foo": "bar"}
-				ITest.Client.Update(ITest.Context, request)
-			}
-		}).Should(Succeed())
-	})
-
-})
-
-var _ = Describe("With binding is ready", func() {
-	var createdRequest *api.SPIFileContentRequest
-
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		ITest.TestServiceProvider.DownloadFileCapability = func() serviceprovider.DownloadFileCapability { return testCapability{} }
-		createdRequest = &api.SPIFileContentRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "filerequest-",
-				Namespace:    "default",
-			},
-			Spec: api.SPIFileContentRequestSpec{
-				RepoUrl:  "test-provider://test",
-				FilePath: "foo/bar.txt",
-			},
-		}
-		Expect(ITest.Client.Create(ITest.Context, createdRequest)).To(Succeed())
-
-		token := &api.SPIAccessToken{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "status-updates-better-",
-				Namespace:    "default",
-				Annotations: map[string]string{
-					"dummy": "true",
+			Behavior: ITestBehavior{
+				BeforeObjectsCreated: func() {
+					ITest.TestServiceProvider.DownloadFileCapability = func() serviceprovider.DownloadFileCapability { return testCapability{} }
+					ITest.TestServiceProvider.GetOauthEndpointImpl = func() string {
+						return "test-provider://test"
+					}
 				},
 			},
-			Spec: api.SPIAccessTokenSpec{
-				ServiceProviderUrl: "test-provider://",
-			},
 		}
-
-		Expect(ITest.Client.Create(ITest.Context, token)).To(Succeed())
-
-		ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
-			Username:             "alois",
-			UserId:               "42",
-			Scopes:               []string{},
-			ServiceProviderState: []byte("state"),
+		BeforeEach(func() {
+			testSetup.BeforeEach(nil)
 		})
-		err := ITest.TokenStorage.Store(ITest.Context, token, &api.Token{
-			AccessToken: "token",
+
+		var _ = AfterEach(func() {
+			testSetup.AfterEach()
 		})
-		Expect(err).NotTo(HaveOccurred())
-		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&token)
+
+		It("have the status awaiting set", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				g.Expect(testSetup.InCluster.FileContentRequests[0].Status.Phase == api.SPIFileContentRequestPhaseAwaitingTokenData).To(BeTrue())
+			})
+		})
+
+		It("have the upload and OAUth URLs set", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				request := testSetup.InCluster.FileContentRequests[0]
+				g.Expect(request.Status.TokenUploadUrl).NotTo(BeEmpty())
+				g.Expect(request.Status.OAuthUrl).NotTo(BeEmpty())
+			})
+		})
 	})
 
-	var _ = AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIFileContentRequest{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
-	})
-
-	It("sets request into delivered, too", func() {
-		Eventually(func(g Gomega) {
-			request := &api.SPIFileContentRequest{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), request)).To(Succeed())
-			g.Expect(request.Status.Phase).To(Equal(api.SPIFileContentRequestPhaseDelivered))
-			g.Expect(request.Status.Content).To(Equal(base64.StdEncoding.EncodeToString([]byte("abcdefg"))))
-		}).Should(Succeed())
-	})
-})
-
-var _ = Describe("With binding is ready but provider doesn't support  downloads", func() {
-	var createdRequest *api.SPIFileContentRequest
-
-	BeforeEach(func() {
-		ITest.TestServiceProvider.Reset()
-		ITest.TestServiceProvider.DownloadFileCapability = nil
-		createdRequest = &api.SPIFileContentRequest{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "filerequest-",
-				Namespace:    "default",
+	Describe("With binding is in error", func() {
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				FileContentRequests: []*api.SPIFileContentRequest{StandardFileRequest("create-with-binding-in-error")},
 			},
-			Spec: api.SPIFileContentRequestSpec{
-				RepoUrl:  "test-provider://test",
-				FilePath: "foo/bar.txt",
-			},
-		}
-		Expect(ITest.Client.Create(ITest.Context, createdRequest)).To(Succeed())
-
-		token := &api.SPIAccessToken{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "status-updates-better-",
-				Namespace:    "default",
-				Annotations: map[string]string{
-					"dummy": "true",
+			Behavior: ITestBehavior{
+				BeforeObjectsCreated: func() {
+					ITest.TestServiceProvider.DownloadFileCapability = func() serviceprovider.DownloadFileCapability { return testCapability{} }
+				},
+				AfterObjectsCreated: func(objects TestObjects) {
+					ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
+						Username:             "alois",
+						UserId:               "42",
+						Scopes:               []string{},
+						ServiceProviderState: []byte("state"),
+					})
+					err := ITest.TokenStorage.Store(ITest.Context, objects.Tokens[0], &api.Token{
+						AccessToken: "token",
+					})
+					Expect(err).NotTo(HaveOccurred())
 				},
 			},
-			Spec: api.SPIAccessTokenSpec{
-				ServiceProviderUrl: "test-provider://",
+		}
+
+		BeforeEach(func() {
+			testSetup.BeforeEach(func(g Gomega) {
+				g.Expect(testSetup.InCluster.Bindings[0].Status.Phase).To(Equal(api.SPIAccessTokenBindingPhaseError))
+			})
+		})
+
+		var _ = AfterEach(func() {
+			testSetup.AfterEach()
+		})
+
+		It("sets request into error too", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				request := testSetup.InCluster.FileContentRequests[0]
+				g.Expect(request.Status.Phase).To(Equal(api.SPIFileContentRequestPhaseError))
+				g.Expect(request.Status.ErrorMessage).To(HavePrefix("linked binding is in error state"))
+			})
+		})
+
+	})
+
+	Describe("Request is removed", func() {
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				FileContentRequests: []*api.SPIFileContentRequest{StandardFileRequest("request-removal")},
+			},
+			Behavior: ITestBehavior{
+				BeforeObjectsCreated: func() {
+					ITest.TestServiceProvider.DownloadFileCapability = func() serviceprovider.DownloadFileCapability { return testCapability{} }
+				},
 			},
 		}
 
-		Expect(ITest.Client.Create(ITest.Context, token)).To(Succeed())
-
-		ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
-			Username:             "alois",
-			UserId:               "42",
-			Scopes:               []string{},
-			ServiceProviderState: []byte("state"),
+		BeforeEach(func() {
+			testSetup.BeforeEach(nil)
 		})
-		err := ITest.TokenStorage.Store(ITest.Context, token, &api.Token{
-			AccessToken: "token",
+
+		AfterEach(func() {
+			testSetup.AfterEach()
 		})
-		Expect(err).NotTo(HaveOccurred())
-		ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&token)
+
+		It("it removes the binding, too", func() {
+			// let's just double-check that we indeed have the binding
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				req := testSetup.InCluster.FileContentRequests[0]
+				g.Expect(testSetup.InCluster.GetBinding(client.ObjectKey{Name: req.Status.LinkedBindingName, Namespace: req.Namespace})).NotTo(BeNil())
+			})
+
+			Expect(ITest.Client.Delete(ITest.Context, testSetup.InCluster.FileContentRequests[0])).To(Succeed())
+
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				g.Expect(testSetup.InCluster.Bindings).To(BeEmpty())
+			})
+		})
+
+		It("should delete request by timeout", func() {
+			ITest.OperatorConfiguration.FileContentRequestTtl = 500 * time.Millisecond
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				g.Expect(testSetup.InCluster.FileContentRequests).To(BeEmpty())
+			})
+		})
 	})
 
-	var _ = AfterEach(func() {
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIFileContentRequest{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessTokenBinding{}, client.InNamespace("default"))).To(Succeed())
-		Expect(ITest.Client.DeleteAllOf(ITest.Context, &api.SPIAccessToken{}, client.InNamespace("default"))).To(Succeed())
+	Describe("With binding is ready", func() {
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				FileContentRequests: []*api.SPIFileContentRequest{StandardFileRequest("binding-ready")},
+				Tokens:              []*api.SPIAccessToken{StandardTestToken("binding-ready")},
+			},
+			Behavior: ITestBehavior{
+				BeforeObjectsCreated: func() {
+					ITest.TestServiceProvider.DownloadFileCapability = func() serviceprovider.DownloadFileCapability { return testCapability{} }
+				},
+				AfterObjectsCreated: func(objects TestObjects) {
+					token := objects.GetTokensByNamePrefix(client.ObjectKey{Name: "binding-ready", Namespace: "default"})[0]
+
+					ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
+						Username:             "alois",
+						UserId:               "42",
+						Scopes:               []string{},
+						ServiceProviderState: []byte("state"),
+					})
+					err := ITest.TokenStorage.Store(ITest.Context, token, &api.Token{
+						AccessToken: "token",
+					})
+					Expect(err).NotTo(HaveOccurred())
+					ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&token)
+				},
+			},
+		}
+
+		BeforeEach(func() {
+			testSetup.BeforeEach(nil)
+		})
+
+		AfterEach(func() {
+			testSetup.AfterEach()
+		})
+
+		It("sets request into delivered, too", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				request := testSetup.InCluster.FileContentRequests[0]
+				g.Expect(request.Status.Phase).To(Equal(api.SPIFileContentRequestPhaseDelivered))
+				g.Expect(request.Status.Content).To(Equal(base64.StdEncoding.EncodeToString([]byte("abcdefg"))))
+			})
+		})
 	})
 
-	It("sets request into error, too", func() {
-		Eventually(func(g Gomega) {
-			request := &api.SPIFileContentRequest{}
-			g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKeyFromObject(createdRequest), request)).To(Succeed())
-			g.Expect(request.Status.Phase).To(Equal(api.SPIFileContentRequestPhaseError))
-		}).Should(Succeed())
-	})
+	Describe("With binding is ready but provider doesn't support  downloads", func() {
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				FileContentRequests: []*api.SPIFileContentRequest{StandardFileRequest("binding-ready-no-download")},
+				Tokens:              []*api.SPIAccessToken{StandardTestToken("binding-ready-no-download")},
+			},
+			Behavior: ITestBehavior{
+				AfterObjectsCreated: func(objects TestObjects) {
+					token := objects.GetTokensByNamePrefix(client.ObjectKey{Name: "binding-ready-no-download", Namespace: "default"})[0]
 
+					ITest.TestServiceProvider.PersistMetadataImpl = PersistConcreteMetadata(&api.TokenMetadata{
+						Username:             "alois",
+						UserId:               "42",
+						Scopes:               []string{},
+						ServiceProviderState: []byte("state"),
+					})
+					err := ITest.TokenStorage.Store(ITest.Context, token, &api.Token{
+						AccessToken: "token",
+					})
+					Expect(err).NotTo(HaveOccurred())
+					ITest.TestServiceProvider.LookupTokenImpl = LookupConcreteToken(&token)
+				},
+			},
+		}
+		BeforeEach(func() {
+			testSetup.BeforeEach(nil)
+		})
+
+		var _ = AfterEach(func() {
+			testSetup.AfterEach()
+		})
+
+		It("sets request into error, too", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				g.Expect(testSetup.InCluster.FileContentRequests[0].Status.Phase).To(Equal(api.SPIFileContentRequestPhaseError))
+			})
+		})
+	})
 })


### PR DESCRIPTION
### What does this PR do?
This converts the rest of the integration tests to the new Test Setup logic.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-198
https://github.com/redhat-appstudio/service-provider-integration-operator/pull/348

Note that this builds on top of #348 so the diff is rather large now but should be much smaller once #348 is merged.

### How to test this PR?
no new logic, just changes in the integration tests