### PR TITLE
Align Grafana's timeInterval  with Prometheus scrape_interval

### DIFF
--- a/hack/deploy-minikube-monitoring.sh
+++ b/hack/deploy-minikube-monitoring.sh
@@ -247,7 +247,7 @@ spec:
       editable: true
       jsonData:
         tlsSkipVerify: true
-        timeInterval: "5s"
+        timeInterval: "30s"
 EOF
 
 # id 3662


### PR DESCRIPTION
### What does this PR do?
I have issues with grafana's panel that should display reconcile rate of my operator. It has such a query:
```
sum by (result) (rate(controller_runtime_reconcile_total{namespace="$Namespace", service="$Service", pod="$Pod"}[$__rate_interval]))
```
on small intervals (less than two days) it shows me nothing.
After reading this article https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/
I come to the thought that it's because of scrape intervals Prometues to app/Grafana to Prometheus. So I've changed the value in my Grafana data source(timeInterval) from 5s to 30s(same as Prometues scrape_interval). Then I got some data in intervals of less than two days.

See more https://coreos.slack.com/archives/C0VMT03S5/p1671610444138839
### Screenshot/screencast of this PR
n/a


### What issues does this PR fix or reference?
I have issues with grafana's panel that should display reconcile rate of my operator.

### How to test this PR?
 - deploy monitoring.
 - do some operation with spi
 - check operator metrics dashboard
