### PR TITLE
Upgrade go-hclog v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
-	github.com/hashicorp/go-hclog v1.3.1
+	github.com/hashicorp/go-hclog v1.4.0
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/vault v1.12.2
 	github.com/hashicorp/vault-plugin-secrets-kv v0.13.3

--- a/go.sum
+++ b/go.sum
@@ -647,8 +647,9 @@ github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v1.3.1 h1:vDwF1DFNZhntP4DAjuTpOw3uEgMUpXh1pB5fW9DqHpo=
 github.com/hashicorp/go-hclog v1.3.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.4.0 h1:ctuWFGrhFha8BnnzxqeRGidlEcQkDyL5u8J8t5eA11I=
+github.com/hashicorp/go-hclog v1.4.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=

--- a/pkg/logs/hclog.go
+++ b/pkg/logs/hclog.go
@@ -154,6 +154,23 @@ func (l *HCLogAdapter) ResetNamed(name string) hclog.Logger {
 func (l *HCLogAdapter) SetLevel(level hclog.Level) {
 }
 
+// GetLevel has no implementation.
+func (l *HCLogAdapter) GetLevel() hclog.Level {
+	switch l.zap.Level() {
+	case zapcore.DebugLevel:
+		return hclog.Debug
+	case zapcore.InfoLevel:
+		return hclog.Info
+	case zapcore.WarnLevel:
+		return hclog.Warn
+	case zapcore.ErrorLevel, zapcore.DPanicLevel, zapcore.PanicLevel, zapcore.FatalLevel:
+		return hclog.Error
+	default:
+		return hclog.Off
+
+	}
+}
+
 func (l *HCLogAdapter) StandardLogger(opts *hclog.StandardLoggerOptions) *log.Logger {
 	return zap.NewStdLog(l.zap)
 }

--- a/pkg/logs/hclog_test.go
+++ b/pkg/logs/hclog_test.go
@@ -89,6 +89,26 @@ func TestHCLogAdapter_Log(t *testing.T) {
 	})
 }
 
+func TestHCLogAdapter_GetLevel(t *testing.T) {
+	tests := []struct {
+		testLevel     zapcore.Level
+		expectedLevel hclog.Level
+	}{
+		{zapcore.DebugLevel, hclog.Debug},
+		{zapcore.InfoLevel, hclog.Info},
+		{zapcore.WarnLevel, hclog.Warn},
+		{zapcore.ErrorLevel, hclog.Error},
+		{zapcore.DPanicLevel, hclog.Error},
+		{zapcore.PanicLevel, hclog.Error},
+		{zapcore.FatalLevel, hclog.Error},
+	}
+	for _, tt := range tests {
+		withLogger(tt.testLevel, nil, func(logger *HCLogAdapter, logs *observer.ObservedLogs) {
+			assert.Equal(t, tt.expectedLevel, logger.GetLevel(), "Unexpected output %s-level from GetLevel method.", tt.expectedLevel)
+		})
+	}
+}
+
 func TestHCLogAdapter_ShouldDiscardOffLevel(t *testing.T) {
 	withLogger(zap.DebugLevel, nil, func(logger *HCLogAdapter, logs *observer.ObservedLogs) {
 		logger.Log(hclog.Off, "Message", "param", "pam-pam")


### PR DESCRIPTION
### What does this PR do?
Upgrade go-hclog v1.4.0

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
- generic dependencies maintenance
- https://github.com/redhat-appstudio/service-provider-integration-operator/pull/363 is not buildable.


### How to test this PR?
- setup SPI
- generic testing
