### PR TITLE
add the ability to focus the Ginkgo integration tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ SPIS_IMG ?= $(SPIS_IMAGE_TAG_BASE):$(TAG_NAME)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = latest
 
+# this variable is used to enable the `make itest focus=...` syntax for running subset of integration test suite.
 focus ?= ""
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ SPIS_IMG ?= $(SPIS_IMAGE_TAG_BASE):$(TAG_NAME)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = latest
 
+focus ?= ""
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -167,8 +169,8 @@ test: manifests generate envtest ## Run unit tests
 	$(K8S_CLI) apply -k ./config/crd
 	GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=10s KUBEBUILDER_ASSETS="$(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -covermode=atomic -coverpkg=./...
 
-itest: manifests generate envtest ## Run only integration tests.
-	GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=10s KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./integration_tests/...
+itest: manifests generate envtest ## Run only integration tests. Use make itest focus=... to focus Ginkgo only to certain tests
+	GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=10s KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" ginkgo -v -progress -focus="${focus}" ./integration_tests/...
 
 
 itest_debug: manifests generate envtest ## Start the integration tests in the debugger (suited for "remote debugging")


### PR DESCRIPTION
### What does this PR do?
`$TITLE`

### What issues does this PR fix or reference?
none

### How to test this PR?
`make itest focus="SPIAccessToken"` should only integration tests related to `SPIAccessToken` using the Ginkgo's focus mechanism.