### PR TITLE
Do not fail in case if findOauthConfigSecret request is not unauthorized

### DIFF
--- a/oauth/oauth_config.go
+++ b/oauth/oauth_config.go
@@ -103,7 +103,7 @@ func (c *commonController) findOauthConfigSecret(ctx context.Context, tokenNames
 			lg.Info("not enough permissions to list the secrets")
 			return false, nil, nil
 		} else if kuberrors.IsUnauthorized(listErr) {
-			lg.Info("request is not authorized to list the secrets")
+			lg.Info("request is not authorized to list the secrets in user's namespace")
 			return false, nil, nil
 		} else {
 			return false, nil, fmt.Errorf("failed to list oauth config secrets: %w", listErr)


### PR DESCRIPTION
### What does this PR do?
The temporary solution to unblock OAuth flow on staging until we found why the request is not authorized

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-288


### How to test this PR?
n/a