### PR TITLE
Run the integration tests using the normal go test. Don't require ginkgo to be installed in the PATH.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,8 +171,7 @@ test: manifests generate envtest ## Run unit tests
 	GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=10s KUBEBUILDER_ASSETS="$(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out -covermode=atomic -coverpkg=./...
 
 itest: manifests generate envtest ## Run only integration tests. Use make itest focus=... to focus Ginkgo only to certain tests
-	GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=10s KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" ginkgo -v -progress -focus="${focus}" ./integration_tests/...
-
+	GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=10s KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./integration_tests/... -ginkgo.focus="${focus}" -ginkgo.progress 
 
 itest_debug: manifests generate envtest ## Start the integration tests in the debugger (suited for "remote debugging")
 	$(shell rm ./debug.out)


### PR DESCRIPTION
### What does this PR do?
`$TITLE`

### What issues does this PR fix or reference?
none

### How to test this PR?
`make itest` should work even without `ginkgo` being installed.