### PR TITLE
handle the uninitialized service provider state in Quay's FetchRepo

### DIFF
--- a/pkg/serviceprovider/quay/metadataprovider.go
+++ b/pkg/serviceprovider/quay/metadataprovider.go
@@ -163,10 +163,14 @@ func (p metadataProvider) doFetchRepo(ctx context.Context, repoUrl string, token
 	}
 
 	quayState := TokenState{}
-	if err = json.Unmarshal(token.Status.TokenMetadata.ServiceProviderState, &quayState); err != nil {
-		lg.Error(err, "failed to unmarshal quay token state")
-		err = fmt.Errorf("failed to unmarshal the token state: %w", err)
-		return
+	// the service provider state may be nil, so we need to be careful here
+	stateBytes := token.Status.TokenMetadata.ServiceProviderState
+	if len(stateBytes) > 0 {
+		if err = json.Unmarshal(stateBytes, &quayState); err != nil {
+			lg.Error(err, "failed to unmarshal quay token state")
+			err = fmt.Errorf("failed to unmarshal the token state: %w", err)
+			return
+		}
 	}
 	if quayState.Repositories == nil || quayState.Organizations == nil {
 		lg.Info("Detected quay token state with empty Repositories or Organizations")

--- a/pkg/serviceprovider/quay/metadataprovider.go
+++ b/pkg/serviceprovider/quay/metadataprovider.go
@@ -172,15 +172,11 @@ func (p metadataProvider) doFetchRepo(ctx context.Context, repoUrl string, token
 			return
 		}
 	}
-	if quayState.Repositories == nil || quayState.Organizations == nil {
-		lg.Info("Detected quay token state with empty Repositories or Organizations")
-		if quayState.Repositories == nil {
-			quayState.Repositories = make(map[string]EntityRecord)
-		}
-
-		if quayState.Organizations == nil {
-			quayState.Organizations = make(map[string]EntityRecord)
-		}
+	if quayState.Repositories == nil {
+		quayState.Repositories = make(map[string]EntityRecord)
+	}
+	if quayState.Organizations == nil {
+		quayState.Organizations = make(map[string]EntityRecord)
 	}
 
 	var tokenData *api.Token
@@ -242,8 +238,6 @@ func (p metadataProvider) doFetchRepo(ctx context.Context, repoUrl string, token
 	var orgChanged, repoChanged bool
 	var orgRecord, repoRecord EntityRecord
 
-	cached = false
-
 	orgRecord, orgChanged, err = p.getEntityRecord(log.IntoContext(ctx, lg.WithValues("entityType", "organization")), tokenData, orgOrUser, quayState.Organizations, getLoginTokenInfo, fetchOrganizationRecord)
 	if err != nil {
 		lg.Error(err, "failed to read the organization metadata")
@@ -263,9 +257,6 @@ func (p metadataProvider) doFetchRepo(ctx context.Context, repoUrl string, token
 			lg.Error(err, "failed to persist the metadata changes")
 			return
 		}
-	} else {
-		// neither org, nor repo cache records changed, so this was read from the cache.
-		cached = true
 	}
 
 	metadata = &RepositoryMetadata{


### PR DESCRIPTION
### What does this PR do?
This fixes the issue with handling uninitialized service provider state in Quay's incremental metadata loading (`FetchRepo`).

Since the fix for faster metadata loading with the default match-any token lookup strategy, we may leave the service provider state in the token metadata uninitialized.

But we do need the data from Quay when we're mapping the token to the secret. Therefore, when we fetch the repo metadata we need to take into the account the possibility of uninitialized service provider state.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-298

### How to test this PR?
1. Create a binding to a Quay repo
2. Either upload the token data or go through the OAuth flow
3. The secret should be correctly filled with the data.