### PR TITLE
Update link to grafana dashboards with each tekton build

### DIFF
--- a/.tekton/controller-push.yaml
+++ b/.tekton/controller-push.yaml
@@ -25,6 +25,7 @@ spec:
         awk  -i inplace -v n=1 '/newTag:/ { if (++count == n) sub(/newTag:.*/, "newTag: {{ revision }}")} 1' components/spi/base/kustomization.yaml
         awk  -i inplace -v n=2 '/newTag:/ { if (++count == n) sub(/newTag:.*/, "newTag: {{ revision }}")} 1' components/spi/base/kustomization.yaml
         sed -i -e 's|\(https://github.com/redhat-appstudio/service-provider-integration-operator/config/vault/openshift?ref=\)\(.*\)|\1{{ revision }}|' components/spi-vault/kustomization.yaml
+        sed -i -e 's|\(https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/base?ref=\)\(.*\)|\1{{ revision }}|' components/monitoring/grafana/base/kustomization.yaml
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest


### PR DESCRIPTION
### What does this PR do?
Update link to grafana dashboards with each tekton build
Same as here https://github.com/redhat-appstudio/infra-deployments/pull/1159 but automatically .
### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-264


### How to test this PR?
n/a
