### PR TITLE
move storage implementations to own packages

### DIFF
--- a/cmd/oauth/oauth.go
+++ b/cmd/oauth/oauth.go
@@ -38,6 +38,7 @@ import (
 	oauth2 "github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider/oauth"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	authz "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -97,9 +98,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	vaultConfig := tokenstorage.VaultStorageConfigFromCliArgs(&args.VaultCliArgs)
+	vaultConfig := vaultstorage.VaultStorageConfigFromCliArgs(&args.VaultCliArgs)
 	vaultConfig.MetricsRegisterer = metrics.Registry
-	strg, err := tokenstorage.NewVaultStorage(vaultConfig)
+	strg, err := vaultstorage.NewVaultStorage(vaultConfig)
 	if err != nil {
 		setupLog.Error(err, "failed to create token storage interface")
 		os.Exit(1)

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -35,7 +35,7 @@ import (
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider/hostcredentials"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider/quay"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/controllers"
@@ -99,10 +99,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	vaultConfig := tokenstorage.VaultStorageConfigFromCliArgs(&args.VaultCliArgs)
+	vaultConfig := vaultstorage.VaultStorageConfigFromCliArgs(&args.VaultCliArgs)
 	// use the same metrics registry as the controller-runtime
 	vaultConfig.MetricsRegisterer = metrics.Registry
-	strg, err := tokenstorage.NewVaultStorage(vaultConfig)
+	strg, err := vaultstorage.NewVaultStorage(vaultConfig)
 	if err != nil {
 		setupLog.Error(err, "failed to initialize the token storage")
 		os.Exit(1)

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -36,6 +36,7 @@ import (
 	config2 "github.com/onsi/ginkgo/config"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 
 	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
@@ -197,7 +198,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	var strg tokenstorage.TokenStorage
-	ITest.VaultTestCluster, strg, _, _ = tokenstorage.CreateTestVaultTokenStorageWithAuthAndMetrics(GinkgoT(), ITest.MetricsRegistry)
+	ITest.VaultTestCluster, strg, _, _ = vaultstorage.CreateTestVaultTokenStorageWithAuthAndMetrics(GinkgoT(), ITest.MetricsRegistry)
 
 	ITest.TokenStorage = &tokenstorage.NotifyingTokenStorage{
 		Client:       cl,

--- a/oauth/config.go
+++ b/oauth/config.go
@@ -17,13 +17,13 @@ import (
 	"fmt"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 )
 
 type OAuthServiceCliArgs struct {
 	config.CommonCliArgs
 	config.LoggingCliArgs
-	tokenstorage.VaultCliArgs
+	vaultstorage.VaultCliArgs
 	ServiceAddr     string `arg:"--service-addr, env" default:"0.0.0.0:8000" help:"Service address to listen on"`
 	AllowedOrigins  string `arg:"--allowed-origins, env" default:"https://console.dev.redhat.com,https://prod.foo.redhat.com:1337" help:"Comma-separated list of domains allowed for cross-domain requests"`
 	KubeConfig      string `arg:"--kubeconfig, env" default:"" help:""`

--- a/oauth/suite_test.go
+++ b/oauth/suite_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -111,7 +112,7 @@ var _ = BeforeSuite(func() {
 	IT.Clientset, err = kubernetes.NewForConfig(IT.TestEnvironment.Config)
 	Expect(err).NotTo(HaveOccurred())
 
-	IT.VaultTestCluster, IT.TokenStorage = tokenstorage.CreateTestVaultTokenStorage(GinkgoT())
+	IT.VaultTestCluster, IT.TokenStorage = vaultstorage.CreateTestVaultTokenStorage(GinkgoT())
 
 	err = IT.TokenStorage.Initialize(ctx)
 	Expect(err).NotTo(HaveOccurred())

--- a/oauth/token_upload_test.go
+++ b/oauth/token_upload_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,7 +46,7 @@ func TestTokenUploader_ShouldUploadWithNoError(t *testing.T) {
 
 	strg := tokenstorage.NotifyingTokenStorage{
 		Client: cl,
-		TokenStorage: tokenstorage.TestTokenStorage{
+		TokenStorage: vaultstorage.TestTokenStorage{
 			StoreImpl: func(ctx context.Context, token *v1beta1.SPIAccessToken, data *v1beta1.Token) error {
 				assert.Equal(t, cntx, ctx)
 				assert.Equal(t, "jdoe", data.Username)
@@ -88,7 +89,7 @@ func TestTokenUploader_ShouldFailTokenNotFound(t *testing.T) {
 
 	strg := tokenstorage.NotifyingTokenStorage{
 		Client: cl,
-		TokenStorage: tokenstorage.TestTokenStorage{
+		TokenStorage: vaultstorage.TestTokenStorage{
 			StoreImpl: func(ctx context.Context, token *v1beta1.SPIAccessToken, data *v1beta1.Token) error {
 				assert.Fail(t, "This line should not be reached")
 				return nil
@@ -126,7 +127,7 @@ func TestTokenUploader_ShouldFailOnStorage(t *testing.T) {
 
 	strg := tokenstorage.NotifyingTokenStorage{
 		Client: cl,
-		TokenStorage: tokenstorage.TestTokenStorage{
+		TokenStorage: vaultstorage.TestTokenStorage{
 			StoreImpl: func(ctx context.Context, token *v1beta1.SPIAccessToken, data *v1beta1.Token) error {
 				return fmt.Errorf("storage disconnected")
 			},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 )
@@ -34,7 +34,7 @@ const (
 type OperatorCliArgs struct {
 	config.CommonCliArgs
 	config.LoggingCliArgs
-	tokenstorage.VaultCliArgs
+	vaultstorage.VaultCliArgs
 	EnableLeaderElection        bool          `arg:"--leader-elect, env" default:"false" help:"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager."`
 	TokenMetadataCacheTtl       time.Duration `arg:"--metadata-cache-ttl, env" default:"1h" help:"The maximum age of token metadata data cache"`
 	TokenLifetimeDuration       time.Duration `arg:"--token-ttl, env" default:"120h" help:"the time after which a token will be automatically deleted in hours, minutes or seconds. Examples:  \"3h\",  \"5h30m40s\" etc"`

--- a/pkg/serviceprovider/github/downloadfilecapability_test.go
+++ b/pkg/serviceprovider/github/downloadfilecapability_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +52,7 @@ func TestGetFileHead(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -100,7 +100,7 @@ func TestGetFileHeadGitSuffix(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -147,7 +147,7 @@ func TestGetFileOnBranch(t *testing.T) {
 			return nil, fmt.Errorf("unexpected request to: %s", r.URL.String())
 		}),
 	}
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -196,7 +196,7 @@ func TestGetFileOnCommitId(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -234,7 +234,7 @@ func TestGetUnexistingFile(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",

--- a/pkg/serviceprovider/github/github_test.go
+++ b/pkg/serviceprovider/github/github_test.go
@@ -19,7 +19,7 @@ import (
 	"context"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"golang.org/x/oauth2"
 
 	"errors"
@@ -385,7 +385,7 @@ func mockGithub(cl client.Client, returnCode int, httpErr error, lookupError err
 		ExpirationPolicy:          &serviceprovider.NeverMetadataExpirationPolicy{},
 		CacheServiceProviderState: true,
 	}
-	ts := tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+	ts := vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 		return &api.Token{AccessToken: "blabol"}, nil
 	}}
 

--- a/pkg/serviceprovider/github/metadataprovider_test.go
+++ b/pkg/serviceprovider/github/metadataprovider_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -406,7 +406,7 @@ func TestMetadataProvider_Fetch(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -460,7 +460,7 @@ func TestMetadataProvider_Fetch_User_fail(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -506,7 +506,7 @@ func TestMetadataProvider_FetchAll_fail(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -554,7 +554,7 @@ func TestMetadataProvider_Fetch_state_handling(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",

--- a/pkg/serviceprovider/gitlab/downloadfilecapability_test.go
+++ b/pkg/serviceprovider/gitlab/downloadfilecapability_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,7 +54,7 @@ func TestGetFileHead(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -101,7 +101,7 @@ func TestGetFileHeadGitSuffix(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -148,7 +148,7 @@ func TestGetFileOnBranch(t *testing.T) {
 			return nil, fmt.Errorf("unexpected request to: %s", r.URL.String())
 		}),
 	}
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -186,7 +186,7 @@ func TestGetUnexistingFile(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",

--- a/pkg/serviceprovider/gitlab/gitlab_test.go
+++ b/pkg/serviceprovider/gitlab/gitlab_test.go
@@ -27,9 +27,9 @@ import (
 	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
@@ -272,7 +272,7 @@ func mockGitlab(cl client.Client, returnCode int, body string, responseError err
 		ExpirationPolicy:          &serviceprovider.NeverMetadataExpirationPolicy{},
 		CacheServiceProviderState: true,
 	}
-	tokenStorageMock := tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+	tokenStorageMock := vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 		return &api.Token{AccessToken: "access_tolkien"}, nil
 	}}
 

--- a/pkg/serviceprovider/gitlab/metadataprovider_test.go
+++ b/pkg/serviceprovider/gitlab/metadataprovider_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,7 +58,7 @@ func TestFetch_Success(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: tokenStorageGet,
 	}
 	mp := metadataProvider{
@@ -106,7 +106,7 @@ func TestFetch_Success_PatScopes(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: tokenStorageGet,
 	}
 
@@ -141,7 +141,7 @@ func TestFetch_Fail_User(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: tokenStorageGet,
 	}
 	mp := metadataProvider{
@@ -176,7 +176,7 @@ func TestFetch_Fail_Scopes(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: tokenStorageGet,
 	}
 
@@ -230,7 +230,7 @@ func TestMetadataProvider_Fetch_state_handling(t *testing.T) {
 		}),
 	}
 
-	ts := tokenstorage.TestTokenStorage{
+	ts := vaultstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",

--- a/pkg/serviceprovider/hostcredentials/metadataprovider_test.go
+++ b/pkg/serviceprovider/hostcredentials/metadataprovider_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/stretchr/testify/assert"
 )
 
-var ts = tokenstorage.TestTokenStorage{
+var ts = vaultstorage.TestTokenStorage{
 	GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 		return &api.Token{
 			Username:     "test_user",

--- a/pkg/serviceprovider/quay/metadataprovider_test.go
+++ b/pkg/serviceprovider/quay/metadataprovider_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,7 +40,7 @@ import (
 func TestMetadataProvider_Fetch(t *testing.T) {
 
 	t.Run("returns nil when no token data", func(t *testing.T) {
-		ts := tokenstorage.TestTokenStorage{
+		ts := vaultstorage.TestTokenStorage{
 			GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 				return nil, nil
 			},
@@ -94,7 +95,7 @@ func TestMetadataProvider_Fetch(t *testing.T) {
 		}
 
 		t.Run("using oauth token", func(t *testing.T) {
-			ts := tokenstorage.TestTokenStorage{
+			ts := vaultstorage.TestTokenStorage{
 				GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 					return &api.Token{
 						AccessToken: "token",
@@ -106,7 +107,7 @@ func TestMetadataProvider_Fetch(t *testing.T) {
 		})
 
 		t.Run("using robot token", func(t *testing.T) {
-			ts := tokenstorage.TestTokenStorage{
+			ts := vaultstorage.TestTokenStorage{
 				GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 					return &api.Token{
 						AccessToken: "token",
@@ -160,7 +161,7 @@ func TestMetadataProvider_FetchRepo(t *testing.T) {
 		k8sClient := fake.NewClientBuilder().Build()
 
 		mp := metadataProvider{
-			tokenStorage: tokenstorage.TestTokenStorage{
+			tokenStorage: vaultstorage.TestTokenStorage{
 				GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 					return &api.Token{
 						AccessToken: "token",
@@ -187,7 +188,7 @@ func TestMetadataProvider_FetchRepo(t *testing.T) {
 		k8sClient := fake.NewClientBuilder().Build()
 
 		mp := metadataProvider{
-			tokenStorage:     tokenstorage.TestTokenStorage{},
+			tokenStorage:     vaultstorage.TestTokenStorage{},
 			httpClient:       failingHttpClient,
 			kubernetesClient: k8sClient,
 			ttl:              10 * time.Hour,
@@ -211,7 +212,7 @@ func TestMetadataProvider_FetchRepo(t *testing.T) {
 		k8sClient := fake.NewClientBuilder().Build()
 
 		mp := metadataProvider{
-			tokenStorage: tokenstorage.TestTokenStorage{
+			tokenStorage: vaultstorage.TestTokenStorage{
 				GetImpl: func(_ context.Context, _ *api.SPIAccessToken) (*api.Token, error) {
 					// this is the default case, but let's be explicit here
 					return nil, nil
@@ -287,7 +288,7 @@ func TestMetadataProvider_FetchRepo(t *testing.T) {
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(token).Build()
 
 			mp := metadataProvider{
-				tokenStorage: tokenstorage.TestTokenStorage{
+				tokenStorage: vaultstorage.TestTokenStorage{
 					GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 						return &api.Token{
 							AccessToken: "token",
@@ -408,7 +409,7 @@ func TestMetadataProvider_ShouldRecoverFromTokenWithOldStateFormat(t *testing.T)
 			}),
 		}
 		mp := metadataProvider{
-			tokenStorage: tokenstorage.TestTokenStorage{
+			tokenStorage: vaultstorage.TestTokenStorage{
 				GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 					return &api.Token{
 						AccessToken: "token",

--- a/pkg/serviceprovider/quay/quay_test.go
+++ b/pkg/serviceprovider/quay/quay_test.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
@@ -92,7 +92,7 @@ func TestMapToken(t *testing.T) {
 		KubernetesClient: k8sClient,
 		HttpClient:       httpClient,
 		Initializers:     initializers,
-		TokenStorage: tokenstorage.TestTokenStorage{
+		TokenStorage: vaultstorage.TestTokenStorage{
 			GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 				return &api.Token{
 					AccessToken: "accessToken",
@@ -368,7 +368,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 			},
 		},
 	}
-	ts := tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+	ts := vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 		return &api.Token{AccessToken: "blabol"}, nil
 	}}
 
@@ -583,7 +583,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusUnauthorized}, nil
 			}},
 			lookup: lookupMock,
-			tokenStorage: tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+			tokenStorage: vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 				return nil, nil
 			}},
 		}
@@ -606,7 +606,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(publicRepoResponseJson))}, nil
 			}},
 			lookup: lookupMock,
-			tokenStorage: tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+			tokenStorage: vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 				return nil, nil
 			}},
 		}
@@ -629,7 +629,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusUnauthorized}, nil
 			}},
 			lookup: lookupMock,
-			tokenStorage: tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+			tokenStorage: vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 				return &api.Token{AccessToken: "tkn", Username: "alois"}, nil
 			}},
 		}

--- a/pkg/serviceprovider/quay/tokenfilter_test.go
+++ b/pkg/serviceprovider/quay/tokenfilter_test.go
@@ -24,7 +24,7 @@ import (
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -113,7 +113,7 @@ func TestMatches_RobotToken(t *testing.T) {
 			metadataProvider: &metadataProvider{
 				kubernetesClient: kubernetesClient,
 				httpClient:       httpClient,
-				tokenStorage: tokenstorage.TestTokenStorage{
+				tokenStorage: vaultstorage.TestTokenStorage{
 					StoreImpl: func(ctx context.Context, token *api.SPIAccessToken, token2 *api.Token) error {
 						return nil
 					},

--- a/pkg/spi-shared/tokenstorage/secretstorage/secrets.go
+++ b/pkg/spi-shared/tokenstorage/secretstorage/secrets.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokenstorage
+package secretstorage
 
 import (
 	"context"
 	"fmt"
 	"strconv"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/sync"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
@@ -33,10 +34,10 @@ type secretsTokenStorage struct {
 	syncer sync.Syncer
 }
 
-var _ TokenStorage = (*secretsTokenStorage)(nil)
+var _ tokenstorage.TokenStorage = (*secretsTokenStorage)(nil)
 
 // NewSecretsStorage creates a new `TokenStorage` instance using the provided Kubernetes client.
-func NewSecretsStorage(cl client.Client) (TokenStorage, error) {
+func NewSecretsStorage(cl client.Client) (tokenstorage.TokenStorage, error) {
 	return &secretsTokenStorage{Client: cl, syncer: sync.New(cl)}, nil
 }
 

--- a/pkg/spi-shared/tokenstorage/secretstorage/secrets_test.go
+++ b/pkg/spi-shared/tokenstorage/secretstorage/secrets_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokenstorage
+package secretstorage
 
 import (
 	"context"

--- a/pkg/spi-shared/tokenstorage/vaultstorage/testtokenstorage.go
+++ b/pkg/spi-shared/tokenstorage/vaultstorage/testtokenstorage.go
@@ -15,7 +15,7 @@
 //go:build !release
 // +build !release
 
-package tokenstorage
+package vaultstorage
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 
 	"github.com/hashicorp/go-hclog"
 	kv "github.com/hashicorp/vault-plugin-secrets-kv"
@@ -75,20 +76,20 @@ func (t TestTokenStorage) Delete(ctx context.Context, owner *api.SPIAccessToken)
 	return t.DeleteImpl(ctx, owner)
 }
 
-var _ TokenStorage = (*TestTokenStorage)(nil)
+var _ tokenstorage.TokenStorage = (*TestTokenStorage)(nil)
 
-func CreateTestVaultTokenStorage(t vtesting.T) (*vault.TestCluster, TokenStorage) {
+func CreateTestVaultTokenStorage(t vtesting.T) (*vault.TestCluster, tokenstorage.TokenStorage) {
 	t.Helper()
 	cluster, storage, _, _ := createTestVaultTokenStorage(t, false, nil)
 	return cluster, storage
 }
 
-func CreateTestVaultTokenStorageWithAuthAndMetrics(t vtesting.T, metricsRegistry *prometheus.Registry) (*vault.TestCluster, TokenStorage, string, string) {
+func CreateTestVaultTokenStorageWithAuthAndMetrics(t vtesting.T, metricsRegistry *prometheus.Registry) (*vault.TestCluster, tokenstorage.TokenStorage, string, string) {
 	t.Helper()
 	return createTestVaultTokenStorage(t, true, metricsRegistry)
 }
 
-func createTestVaultTokenStorage(t vtesting.T, auth bool, metricsRegistry *prometheus.Registry) (*vault.TestCluster, TokenStorage, string, string) {
+func createTestVaultTokenStorage(t vtesting.T, auth bool, metricsRegistry *prometheus.Registry) (*vault.TestCluster, tokenstorage.TokenStorage, string, string) {
 	t.Helper()
 
 	coreConfig := &vault.CoreConfig{

--- a/pkg/spi-shared/tokenstorage/vaultstorage/tokenstorage_vault_test.go
+++ b/pkg/spi-shared/tokenstorage/vaultstorage/tokenstorage_vault_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokenstorage
+package vaultstorage
 
 import (
 	"context"

--- a/pkg/spi-shared/tokenstorage/vaultstorage/vault.go
+++ b/pkg/spi-shared/tokenstorage/vaultstorage/vault.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokenstorage
+package vaultstorage
 
 import (
 	"context"
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 
 	"github.com/hashicorp/go-hclog"
 
@@ -134,7 +135,7 @@ func VaultStorageConfigFromCliArgs(args *VaultCliArgs) *VaultStorageConfig {
 }
 
 // NewVaultStorage creates a new `TokenStorage` instance using the provided Vault instance.
-func NewVaultStorage(vaultTokenStorageConfig *VaultStorageConfig) (TokenStorage, error) {
+func NewVaultStorage(vaultTokenStorageConfig *VaultStorageConfig) (tokenstorage.TokenStorage, error) {
 	config := vault.DefaultConfig()
 	config.Address = vaultTokenStorageConfig.Host
 	config.Logger = hclog.Default()

--- a/pkg/spi-shared/tokenstorage/vaultstorage/vault_auth.go
+++ b/pkg/spi-shared/tokenstorage/vaultstorage/vault_auth.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokenstorage
+package vaultstorage
 
 import (
 	"errors"

--- a/pkg/spi-shared/tokenstorage/vaultstorage/vault_auth_test.go
+++ b/pkg/spi-shared/tokenstorage/vaultstorage/vault_auth_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokenstorage
+package vaultstorage
 
 import (
 	"io/fs"

--- a/pkg/spi-shared/tokenstorage/vaultstorage/vault_login.go
+++ b/pkg/spi-shared/tokenstorage/vaultstorage/vault_login.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokenstorage
+package vaultstorage
 
 import (
 	"context"

--- a/pkg/spi-shared/tokenstorage/vaultstorage/vault_login_test.go
+++ b/pkg/spi-shared/tokenstorage/vaultstorage/vault_login_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokenstorage
+package vaultstorage
 
 import (
 	"context"

--- a/pkg/spi-shared/tokenstorage/vaultstorage/vault_test.go
+++ b/pkg/spi-shared/tokenstorage/vaultstorage/vault_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokenstorage
+package vaultstorage
 
 import (
 	"testing"


### PR DESCRIPTION
### What does this PR do?
Move vault token storage into `vaultstorage` package and secret storage into `secretstorage` package. This is to prepare to add new aws storage and keep it more separate and clean.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
prepare to https://issues.redhat.com/browse/SVPI-342

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

```
quay.io/redhat-appstudio/pull-request-builds:spi-operator-433
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-433
```

Just refactoring, evertyhing must work as before
