### PR TITLE
Update to the latest ubi-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/ -a ./cmd/operator/ope
 
 # Compose the final image of spi-operator.
 # !!! This must be last one, because we want simple `docker build .` to build the operator image.
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-923.1669829893 as spi-operator
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1049 as spi-operator
 
 # Install the 'shadow-utils' which contains `adduser` and `groupadd` binaries
 RUN microdnf install shadow-utils \

--- a/oauth.Dockerfile
+++ b/oauth.Dockerfile
@@ -21,7 +21,7 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/ -a ./cmd/oauth/oauth.go
 
 # Compose the final image of spi-oauth service
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-923.1669829893 as spi-oauth
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1049 as spi-oauth
 
 # Install the 'shadow-utils' which contains `adduser` and `groupadd` binaries
 RUN microdnf install shadow-utils \


### PR DESCRIPTION
### What does this PR do?
Update to the latest ubi-minimal

NOTE Important to keep the version in the format  registry.access.redhat.com/ubi8/ubi-minimal:8.7-XXX, not  registry.access.redhat.com/ubi8/ubi-minimal:8.7-XXX.YYYY. Dependable is not working with them.

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
Regular dependencies maintenance

### How to test this PR?
- basic testing

```
quay.io/skabashn/service-provider-integration-operator:dockefile_up_2023_02_07__15_52_32
quay.io/skabashn/service-provider-integration-oauth:dockefile_up_2023_02_07__15_52_32
```
