### PR TITLE
Fixup vault pod patching method

### DIFF
--- a/config/vault/k8s/kustomization.yaml
+++ b/config/vault/k8s/kustomization.yaml
@@ -10,6 +10,6 @@ resources:
   - ../base/
   - deployment.yaml
 
-patches:
+patchesStrategicMerge:
   - delete-vault-test.yaml
 

--- a/config/vault/openshift/kustomization.yaml
+++ b/config/vault/openshift/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
   - ../base/
   - deployment.yaml
 
-patches:
+patchesStrategicMerge:
   - delete-vault-test.yaml


### PR DESCRIPTION
Signed-off-by: Max Shaposhnyk <mshaposh@redhat.com>

### What does this PR do?
Since new `kustomize` version `5.0.0`, the `patch` option can be used only for patching objects, and cannot anymore be used in a compatibility mode with the `patchesStrategicMerge`, which must be now used explicitly.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

```
quay.io/redhat-appstudio/pull-request-builds:spi-operator-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
