### PR TITLE
fix: controller img name in github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,6 @@
  -->
 
 ```
-quay.io/redhat-appstudio/pull-request-builds:spi-operator-#
+quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
 quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
 ```


### PR DESCRIPTION
### What does this PR do?
The operator image name is not built with "spi-operator-", rather "spi-controller-" as can be seen on https://quay.io/repository/redhat-appstudio/pull-request-builds?tab=tags

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
If you try to pull operator image with `quay.io/redhat-appstudio/pull-request-builds:spi-operator-` it should not work, but with `quay.io/redhat-appstudio/pull-request-builds:spi-controller-` it should work

```
quay.io/redhat-appstudio/pull-request-builds:spi-operator-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
