### PR TITLE
deploy with aws, 3rd way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,9 +233,15 @@ deploy_minikube: ensure-tmp manifests kustomize deploy_vault_minikube ## Deploy 
 	OAUTH_HOST=spi.`minikube ip`.nip.io VAULT_HOST=`hack/vault-host.sh` SPIO_IMG=$(SPIO_IMG) SPIS_IMG=$(SPIS_IMG) hack/replace_placeholders_and_deploy.sh "${KUSTOMIZE}" "minikube" "minikube"
 	kubectl apply -f .tmp/approle_secret.yaml -n spi-system
 
+deploy_minikube_aws: ensure-tmp manifests kustomize
+	OAUTH_HOST=spi.`minikube ip`.nip.io SPIO_IMG=$(SPIO_IMG) SPIS_IMG=$(SPIS_IMG) hack/replace_placeholders_and_deploy.sh "${KUSTOMIZE}" "minikube_aws" "overlays/minikube_aws"
+
 deploy_openshift: ensure-tmp manifests kustomize deploy_vault_openshift ## Deploy controller to the K8s cluster specified in ~/.kube/config using the OpenShift kustomization
 	VAULT_HOST=`./hack/vault-host.sh` SPIO_IMG=$(SPIO_IMG) SPIS_IMG=$(SPIS_IMG) hack/replace_placeholders_and_deploy.sh "${KUSTOMIZE}" "openshift" "openshift"
 	kubectl apply -f .tmp/approle_secret.yaml -n spi-system
+
+deploy_openshift_aws: ensure-tmp manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config using the OpenShift kustomization with AWS tokenstorage
+	SPIO_IMG=$(SPIO_IMG) SPIS_IMG=$(SPIS_IMG) hack/replace_placeholders_and_deploy.sh "${KUSTOMIZE}" "openshift_aws" "overlays/openshift_aws"
 
 undeploy_k8s: undeploy_vault_k8s ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	if [ ! -d ${TEMP_DIR}/deployment_k8s ]; then echo "No deployment files found in .tmp/deployment_k8s"; exit 1; fi

--- a/config/overlays/minikube_aws/kustomization.yaml
+++ b/config/overlays/minikube_aws/kustomization.yaml
@@ -1,0 +1,30 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: spi-system
+
+resources:
+  - ../../minikube
+
+patches:
+  - path: oauth_aws.patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: spi-oauth-service
+  - path: operator_aws.patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: spi-controller-manager
+  - target:
+      version: v1
+      kind: ConfigMap
+      name: shared-environment-config
+      namespace: system
+    patch: |-
+      - op: add
+        path: /data/TOKENSTORAGE
+        value: "aws"

--- a/config/overlays/minikube_aws/oauth_aws.patch.yaml
+++ b/config/overlays/minikube_aws/oauth_aws.patch.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: not-used
+spec:
+  template:
+    spec:
+      containers:
+        - name: oauth
+          volumeMounts:
+            - mountPath: /etc/spi/secret_id
+              $patch: delete
+            - mountPath: /etc/spi/role_id
+              $patch: delete
+            - mountPath: /etc/spi/aws/config
+              name: aws-secretsmanager-credentials
+              readOnly: true
+              subPath: config
+            - mountPath: /etc/spi/aws/credentials
+              name: aws-secretsmanager-credentials
+              readOnly: true
+              subPath: credentials
+      volumes:
+        - name: vault-approle
+          $patch: delete
+        - name: aws-secretsmanager-credentials
+          secret:
+            secretName: aws-secretsmanager-credentials
+            items:
+              - key: config
+                path: config
+              - key: credentials
+                path: credentials

--- a/config/overlays/minikube_aws/operator_aws.patch.yaml
+++ b/config/overlays/minikube_aws/operator_aws.patch.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: not-used
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          volumeMounts:
+            - mountPath: /etc/spi/secret_id
+              $patch: delete
+            - mountPath: /etc/spi/role_id
+              $patch: delete
+            - mountPath: /etc/spi/aws/config
+              name: aws-secretsmanager-credentials
+              readOnly: true
+              subPath: config
+            - mountPath: /etc/spi/aws/credentials
+              name: aws-secretsmanager-credentials
+              readOnly: true
+              subPath: credentials
+      volumes:
+        - name: vault-approle
+          $patch: delete
+        - name: aws-secretsmanager-credentials
+          secret:
+            secretName: aws-secretsmanager-credentials
+            items:
+              - key: config
+                path: config
+              - key: credentials
+                path: credentials

--- a/config/overlays/openshift_aws/kustomization.yaml
+++ b/config/overlays/openshift_aws/kustomization.yaml
@@ -1,0 +1,30 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+
+namespace: spi-system
+
+resources:
+  - ../../openshift
+
+patches:
+  - path: oauth_aws.patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: spi-oauth-service
+  - path: operator_aws.patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: spi-controller-manager
+  - target:
+      version: v1
+      kind: ConfigMap
+      name: shared-environment-config
+      namespace: system
+    patch: |-
+      - op: add
+        path: /data/TOKENSTORAGE
+        value: "aws"

--- a/config/overlays/openshift_aws/oauth_aws.patch.yaml
+++ b/config/overlays/openshift_aws/oauth_aws.patch.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: not-used
+spec:
+  template:
+    spec:
+      containers:
+        - name: oauth
+          volumeMounts:
+            - mountPath: /etc/spi/secret_id
+              $patch: delete
+            - mountPath: /etc/spi/role_id
+              $patch: delete
+            - mountPath: /etc/spi/aws/config
+              name: aws-secretsmanager-credentials
+              readOnly: true
+              subPath: config
+            - mountPath: /etc/spi/aws/credentials
+              name: aws-secretsmanager-credentials
+              readOnly: true
+              subPath: credentials
+      volumes:
+        - name: vault-approle
+          $patch: delete
+        - name: aws-secretsmanager-credentials
+          secret:
+            secretName: aws-secretsmanager-credentials
+            items:
+              - key: config
+                path: config
+              - key: credentials
+                path: credentials

--- a/config/overlays/openshift_aws/operator_aws.patch.yaml
+++ b/config/overlays/openshift_aws/operator_aws.patch.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: not-used
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          volumeMounts:
+            - mountPath: /etc/spi/secret_id
+              $patch: delete
+            - mountPath: /etc/spi/role_id
+              $patch: delete
+            - mountPath: /etc/spi/aws/config
+              name: aws-secretsmanager-credentials
+              readOnly: true
+              subPath: config
+            - mountPath: /etc/spi/aws/credentials
+              name: aws-secretsmanager-credentials
+              readOnly: true
+              subPath: credentials
+      volumes:
+        - name: vault-approle
+          $patch: delete
+        - name: aws-secretsmanager-credentials
+          secret:
+            secretName: aws-secretsmanager-credentials
+            items:
+              - key: config
+                path: config
+              - key: credentials
+                path: credentials

--- a/hack/create-aws-credentials-secret.sh
+++ b/hack/create-aws-credentials-secret.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+NAMESPACE=spi-system
+SECRET_NAME=aws-secretsmanager-credentials
+
+kubectl create secret generic ${SECRET_NAME} -n ${NAMESPACE} \
+      --from-file=${HOME}/.aws/config \
+      --from-file=${HOME}/.aws/credentials


### PR DESCRIPTION
### What does this PR do?
3rd option to deploy with AWS token storage.
This one makes aws overlays for minikube and openshift and it is trying to be least invasive into current deployment so making everything happen in overlay patches.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-366

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

1. run `make deploy_minikube_aws` or `make deploy_openshift_aws`
2. after you login with aws cli and `~/.aws` folder is created with aws credentials, run `./hack/create-aws-credentials-secret.sh`
3. SPI should start using AWS tokenstorage

```
quay.io/redhat-appstudio/pull-request-builds:spi-operator-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
