### PR TITLE
provide logout endpoint to invalidate user session cookie

### DIFF
--- a/cmd/oauth/oauth.go
+++ b/cmd/oauth/oauth.go
@@ -111,6 +111,7 @@ func main() {
 
 	// auth
 	router.HandleFunc("/login", authenticator.Login).Methods("POST")
+	router.HandleFunc("/logout", authenticator.Logout).Methods("POST")
 
 	// token upload
 	router.NewRoute().Path("/token/{namespace}/{name}").HandlerFunc(oauth.HandleUpload(&tokenUploader)).Methods("POST")

--- a/docs/USER.md
+++ b/docs/USER.md
@@ -502,6 +502,10 @@ This endpoint is used to authenticate `/{sp_type}/authenticate` method with Kube
 
 This endpoint sets a session cookie that is required to be present when completing the OAuth flow in the `/{sp_type}/authenticate` and `/{sp_type}/callback` endpoints.
 
+### POST /logout
+This endpoint is used to invalidate the session cookie set by the `/login` endpoint. 
+It is not required to call this endpoint, as the session cookie expires in 15 minutes after the last request.
+
 #### Response
 - 200 - authorization data successfully accepted.
 - 403 - provided authorization header is not valid.

--- a/hack/oauth-ui.html
+++ b/hack/oauth-ui.html
@@ -9,6 +9,13 @@
             form.submit();
         }
 
+        function logout() {
+            let form = document.getElementById("loginform");
+            let oauthUrl = new URL(document.getElementById("oauth_url").value);
+            form.action = oauthUrl.origin + "/logout";
+            form.submit();
+        }
+
         function oauth_submit() {
             let form = document.getElementById("oauthform");
             let oauthUrl = new URL(document.getElementById("oauth_url").value);
@@ -26,6 +33,7 @@
     <label for="k8s_token">K8s token:</label> <input id="k8s_token" type="text" name="k8s_token"/><br/>
 </form>
 <input type="button" onclick="login()" value="Login"/>
+<input type="button" onclick="logout()" value="Logout"/>
 <form id="oauthform" method="post" target="_blank">
     <input id="state" type="hidden" name="state"/>
 </form>

--- a/oauth/authenticator.go
+++ b/oauth/authenticator.go
@@ -106,6 +106,18 @@ func (a Authenticator) Login(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func (a Authenticator) Logout(w http.ResponseWriter, r *http.Request) {
+	lg := log.FromContext(r.Context())
+	defer logs.TimeTrack(lg, time.Now(), "/logout")
+
+	if err := a.SessionManager.Destroy(r.Context()); err != nil {
+		LogErrorAndWriteResponse(r.Context(), w, http.StatusInternalServerError, "failed to destroy the user session", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
 func NewAuthenticator(sessionManager *scs.SessionManager, cl AuthenticatingClient) *Authenticator {
 	return &Authenticator{
 		K8sClient:      cl,

--- a/oauth/authenticator.go
+++ b/oauth/authenticator.go
@@ -112,9 +112,11 @@ func (a Authenticator) Logout(w http.ResponseWriter, r *http.Request) {
 
 	if err := a.SessionManager.Destroy(r.Context()); err != nil {
 		LogErrorAndWriteResponse(r.Context(), w, http.StatusInternalServerError, "failed to destroy the user session", err)
+		logs.AuditLog(r.Context()).Info("unsuccessful attempt to clear the user session")
 		return
 	}
 
+	logs.AuditLog(r.Context()).Info("successfully cleared the user session")
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/oauth/common_test.go
+++ b/oauth/common_test.go
@@ -211,9 +211,9 @@ var _ = Describe("Controller", func() {
 		Expect(res.Result().Cookies()).NotTo(BeEmpty())
 	})
 
-	It("deauthenticate in POST", func() {
+	It("invalidates the user session cookie", func() {
 
-		req := httptest.NewRequest("POST", "/", nil)
+		req := httptest.NewRequest("GET", "/logout", nil)
 		res := httptest.NewRecorder()
 
 		c := prepareAuthenticator(Default)
@@ -222,7 +222,10 @@ var _ = Describe("Controller", func() {
 		})).ServeHTTP(res, req)
 
 		Expect(res.Code).To(Equal(http.StatusOK))
-		Expect(res.Result().Cookies()).NotTo(BeEmpty())
+		Expect(res.Result().Cookies()).To(HaveLen(1))
+		Expect(res.Result().Cookies()[0].Value).To(BeEmpty())
+		Expect(res.Result().Cookies()[0].MaxAge).To(BeNumerically("<=", 0))
+		Expect(res.Result().Cookies()[0].Expires).To(BeTemporally("<=", time.Now()))
 	})
 
 	It("redirects to SP OAuth URL with state and scopes", func() {

--- a/oauth/common_test.go
+++ b/oauth/common_test.go
@@ -211,6 +211,20 @@ var _ = Describe("Controller", func() {
 		Expect(res.Result().Cookies()).NotTo(BeEmpty())
 	})
 
+	It("deauthenticate in POST", func() {
+
+		req := httptest.NewRequest("POST", "/", nil)
+		res := httptest.NewRecorder()
+
+		c := prepareAuthenticator(Default)
+		IT.SessionManager.LoadAndSave(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			c.Logout(w, r)
+		})).ServeHTTP(res, req)
+
+		Expect(res.Code).To(Equal(http.StatusOK))
+		Expect(res.Result().Cookies()).NotTo(BeEmpty())
+	})
+
 	It("redirects to SP OAuth URL with state and scopes", func() {
 		_, res := loginFlow(Default)
 		Expect(res.Code).To(Equal(http.StatusOK))

--- a/oauth/suite_test.go
+++ b/oauth/suite_test.go
@@ -124,6 +124,8 @@ var _ = BeforeSuite(func() {
 
 	IT.SessionManager = scs.New()
 	IT.SessionManager.Store = memstore.NewWithCleanupInterval(5 * time.Minute)
+	IT.SessionManager.Lifetime = time.Hour
+	IT.SessionManager.Cookie.Persist = false
 	IT.SessionManager.IdleTimeout = 15 * time.Minute
 	IT.SessionManager.Cookie.Name = "appstudio_spi_session"
 	IT.SessionManager.Cookie.SameSite = http.SameSiteNoneMode


### PR DESCRIPTION
### What does this PR do?
$TITLE

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->
![image](https://user-images.githubusercontent.com/73115616/222740234-243a8906-e4c5-4127-81d1-489d916ecf47.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-383

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

1. Deploy with img bellow
2. Create any sample binding
3. Call `/login` through `oauth-ui.html` login button for example. This should set a cookie.
4. Call `/logout` through `oauth-ui.html` logout button for example. This should invalidate the cookie set in the previous step. This means that the cookie value is empty and its expiry attribute is in the past time.
5. Try going through the OAuth flow. It should not be possible as you have no valid session cookie.
```
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
