### PR TITLE
Move TestTokenStorage to a more logical place, use MemoryTokenStorage where possible

### DIFF
--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -38,7 +38,7 @@ import (
 	config2 "github.com/onsi/ginkgo/config"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/memorystorage"
 
 	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
@@ -246,8 +246,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	var strg tokenstorage.TokenStorage
-	ITest.VaultTestCluster, strg, _, _ = vaultstorage.CreateTestVaultTokenStorageWithAuthAndMetrics(GinkgoT(), ITest.MetricsRegistry)
+	strg := &memorystorage.MemoryTokenStorage{}
 
 	ITest.TokenStorage = &tokenstorage.NotifyingTokenStorage{
 		Client:       ITest.Client,

--- a/integration_tests/tokenstorage_acceptance_test.go
+++ b/integration_tests/tokenstorage_acceptance_test.go
@@ -24,10 +24,11 @@ import (
 	"time"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/awsstorage/awscli"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/memorystorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/vaultstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/memorystorage"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -39,23 +40,23 @@ import (
 
 // TestVaultStorage runs against local in-memory Vault. No external dependency or setup is needed, test runs everytime.
 func TestVaultStorage(t *testing.T) {
-	cluster, storage := vaultstorage.CreateTestVaultTokenStorage(t)
+	cluster, storage := vaultstorage.CreateTestVaultSecretStorage(t)
 
 	ctx := context.TODO()
 	assert.NoError(t, storage.Initialize(ctx))
 	defer cluster.Cleanup()
 
-	testStorage(t, ctx, storage)
+	testStorage(t, ctx, createTokenStorage(storage))
 }
 
 // TestInMemoryStorage runs against our testing in-memory implementation of the TokenStorage.
 func TestInMemoryStorage(t *testing.T) {
-	storage := &memorystorage.MemoryTokenStorage{}
+	storage := &memorystorage.MemoryStorage{}
 
 	ctx := context.TODO()
 	assert.NoError(t, storage.Initialize(ctx))
 
-	testStorage(t, ctx, storage)
+	testStorage(t, ctx, createTokenStorage(storage))
 }
 
 // TestAws runs against real AWS secret manager.
@@ -92,6 +93,14 @@ func TestAws(t *testing.T) {
 	assert.NoError(t, err)
 
 	testStorage(t, ctx, storage)
+}
+
+func createTokenStorage(secretStorage secretstorage.SecretStorage) tokenstorage.TokenStorage {
+	return &tokenstorage.DefaultTokenStorage{
+		SecretStorage: secretStorage,
+		Serializer:    tokenstorage.JSONSerializer,
+		Deserializer:  tokenstorage.JSONDeserializer,
+	}
 }
 
 func testStorage(t *testing.T, ctx context.Context, storage tokenstorage.TokenStorage) {

--- a/oauth/suite_test.go
+++ b/oauth/suite_test.go
@@ -24,11 +24,9 @@ import (
 
 	authz "k8s.io/api/authorization/v1"
 
-	"github.com/hashicorp/vault/vault"
-
 	"github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/memorystorage"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -46,16 +44,15 @@ import (
 )
 
 var IT = struct {
-	TestEnvironment  *envtest.Environment
-	Context          context.Context
-	Cancel           context.CancelFunc
-	Scheme           *runtime.Scheme
-	Namespace        string
-	Client           client.Client
-	Clientset        *kubernetes.Clientset
-	TokenStorage     tokenstorage.TokenStorage
-	VaultTestCluster *vault.TestCluster
-	SessionManager   *scs.SessionManager
+	TestEnvironment *envtest.Environment
+	Context         context.Context
+	Cancel          context.CancelFunc
+	Scheme          *runtime.Scheme
+	Namespace       string
+	Client          client.Client
+	Clientset       *kubernetes.Clientset
+	TokenStorage    tokenstorage.TokenStorage
+	SessionManager  *scs.SessionManager
 }{}
 
 func TestSuite(t *testing.T) {
@@ -112,7 +109,7 @@ var _ = BeforeSuite(func() {
 	IT.Clientset, err = kubernetes.NewForConfig(IT.TestEnvironment.Config)
 	Expect(err).NotTo(HaveOccurred())
 
-	IT.VaultTestCluster, IT.TokenStorage = vaultstorage.CreateTestVaultTokenStorage(GinkgoT())
+	IT.TokenStorage = &memorystorage.MemoryTokenStorage{}
 
 	err = IT.TokenStorage.Initialize(ctx)
 	Expect(err).NotTo(HaveOccurred())
@@ -186,5 +183,4 @@ var _ = AfterSuite(func() {
 	Expect(IT.Client.Delete(context.TODO(), ns)).To(Succeed())
 	IT.Cancel()
 	Expect(IT.TestEnvironment.Stop()).To(Succeed())
-	IT.VaultTestCluster.Cleanup()
 })

--- a/oauth/token_upload_test.go
+++ b/oauth/token_upload_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,7 +45,7 @@ func TestTokenUploader_ShouldUploadWithNoError(t *testing.T) {
 
 	strg := tokenstorage.NotifyingTokenStorage{
 		Client: cl,
-		TokenStorage: vaultstorage.TestTokenStorage{
+		TokenStorage: tokenstorage.TestTokenStorage{
 			StoreImpl: func(ctx context.Context, token *v1beta1.SPIAccessToken, data *v1beta1.Token) error {
 				assert.Equal(t, cntx, ctx)
 				assert.Equal(t, "jdoe", data.Username)
@@ -89,7 +88,7 @@ func TestTokenUploader_ShouldFailTokenNotFound(t *testing.T) {
 
 	strg := tokenstorage.NotifyingTokenStorage{
 		Client: cl,
-		TokenStorage: vaultstorage.TestTokenStorage{
+		TokenStorage: tokenstorage.TestTokenStorage{
 			StoreImpl: func(ctx context.Context, token *v1beta1.SPIAccessToken, data *v1beta1.Token) error {
 				assert.Fail(t, "This line should not be reached")
 				return nil
@@ -127,7 +126,7 @@ func TestTokenUploader_ShouldFailOnStorage(t *testing.T) {
 
 	strg := tokenstorage.NotifyingTokenStorage{
 		Client: cl,
-		TokenStorage: vaultstorage.TestTokenStorage{
+		TokenStorage: tokenstorage.TestTokenStorage{
 			StoreImpl: func(ctx context.Context, token *v1beta1.SPIAccessToken, data *v1beta1.Token) error {
 				return fmt.Errorf("storage disconnected")
 			},

--- a/pkg/serviceprovider/github/downloadfilecapability_test.go
+++ b/pkg/serviceprovider/github/downloadfilecapability_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +52,7 @@ func TestGetFileHead(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -100,7 +100,7 @@ func TestGetFileHeadGitSuffix(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -147,7 +147,7 @@ func TestGetFileOnBranch(t *testing.T) {
 			return nil, fmt.Errorf("unexpected request to: %s", r.URL.String())
 		}),
 	}
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -196,7 +196,7 @@ func TestGetFileOnCommitId(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -234,7 +234,7 @@ func TestGetUnexistingFile(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",

--- a/pkg/serviceprovider/github/github_test.go
+++ b/pkg/serviceprovider/github/github_test.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"golang.org/x/oauth2"
 
 	"errors"
@@ -388,7 +388,7 @@ func mockGithub(cl client.Client, returnCode int, httpErr error, lookupError err
 		ExpirationPolicy:          &serviceprovider.NeverMetadataExpirationPolicy{},
 		CacheServiceProviderState: true,
 	}
-	ts := vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+	ts := tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 		return &api.Token{AccessToken: "blabol"}, nil
 	}}
 

--- a/pkg/serviceprovider/github/metadataprovider_test.go
+++ b/pkg/serviceprovider/github/metadataprovider_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -406,7 +406,7 @@ func TestMetadataProvider_Fetch(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -460,7 +460,7 @@ func TestMetadataProvider_Fetch_User_fail(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -506,7 +506,7 @@ func TestMetadataProvider_FetchAll_fail(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -554,7 +554,7 @@ func TestMetadataProvider_Fetch_state_handling(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",

--- a/pkg/serviceprovider/gitlab/downloadfilecapability_test.go
+++ b/pkg/serviceprovider/gitlab/downloadfilecapability_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,7 +54,7 @@ func TestGetFileHead(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -101,7 +101,7 @@ func TestGetFileHeadGitSuffix(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -148,7 +148,7 @@ func TestGetFileOnBranch(t *testing.T) {
 			return nil, fmt.Errorf("unexpected request to: %s", r.URL.String())
 		}),
 	}
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",
@@ -186,7 +186,7 @@ func TestGetUnexistingFile(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",

--- a/pkg/serviceprovider/gitlab/gitlab_test.go
+++ b/pkg/serviceprovider/gitlab/gitlab_test.go
@@ -27,7 +27,7 @@ import (
 	opconfig "github.com/redhat-appstudio/service-provider-integration-operator/pkg/config"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
@@ -272,7 +272,7 @@ func mockGitlab(cl client.Client, returnCode int, body string, responseError err
 		ExpirationPolicy:          &serviceprovider.NeverMetadataExpirationPolicy{},
 		CacheServiceProviderState: true,
 	}
-	tokenStorageMock := vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+	tokenStorageMock := tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 		return &api.Token{AccessToken: "access_tolkien"}, nil
 	}}
 

--- a/pkg/serviceprovider/gitlab/metadataprovider_test.go
+++ b/pkg/serviceprovider/gitlab/metadataprovider_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,7 +58,7 @@ func TestFetch_Success(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: tokenStorageGet,
 	}
 	mp := metadataProvider{
@@ -106,7 +106,7 @@ func TestFetch_Success_PatScopes(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: tokenStorageGet,
 	}
 
@@ -141,7 +141,7 @@ func TestFetch_Fail_User(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: tokenStorageGet,
 	}
 	mp := metadataProvider{
@@ -176,7 +176,7 @@ func TestFetch_Fail_Scopes(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: tokenStorageGet,
 	}
 
@@ -230,7 +230,7 @@ func TestMetadataProvider_Fetch_state_handling(t *testing.T) {
 		}),
 	}
 
-	ts := vaultstorage.TestTokenStorage{
+	ts := tokenstorage.TestTokenStorage{
 		GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 			return &api.Token{
 				AccessToken:  "access",

--- a/pkg/serviceprovider/hostcredentials/metadataprovider_test.go
+++ b/pkg/serviceprovider/hostcredentials/metadataprovider_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/stretchr/testify/assert"
 )
 
-var ts = vaultstorage.TestTokenStorage{
+var ts = tokenstorage.TestTokenStorage{
 	GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 		return &api.Token{
 			Username:     "test_user",

--- a/pkg/serviceprovider/quay/metadataprovider_test.go
+++ b/pkg/serviceprovider/quay/metadataprovider_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,14 +33,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMetadataProvider_Fetch(t *testing.T) {
 
 	t.Run("returns nil when no token data", func(t *testing.T) {
-		ts := vaultstorage.TestTokenStorage{
+		ts := tokenstorage.TestTokenStorage{
 			GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 				return nil, nil
 			},
@@ -95,7 +94,7 @@ func TestMetadataProvider_Fetch(t *testing.T) {
 		}
 
 		t.Run("using oauth token", func(t *testing.T) {
-			ts := vaultstorage.TestTokenStorage{
+			ts := tokenstorage.TestTokenStorage{
 				GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 					return &api.Token{
 						AccessToken: "token",
@@ -107,7 +106,7 @@ func TestMetadataProvider_Fetch(t *testing.T) {
 		})
 
 		t.Run("using robot token", func(t *testing.T) {
-			ts := vaultstorage.TestTokenStorage{
+			ts := tokenstorage.TestTokenStorage{
 				GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 					return &api.Token{
 						AccessToken: "token",
@@ -161,7 +160,7 @@ func TestMetadataProvider_FetchRepo(t *testing.T) {
 		k8sClient := fake.NewClientBuilder().Build()
 
 		mp := metadataProvider{
-			tokenStorage: vaultstorage.TestTokenStorage{
+			tokenStorage: tokenstorage.TestTokenStorage{
 				GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 					return &api.Token{
 						AccessToken: "token",
@@ -188,7 +187,7 @@ func TestMetadataProvider_FetchRepo(t *testing.T) {
 		k8sClient := fake.NewClientBuilder().Build()
 
 		mp := metadataProvider{
-			tokenStorage:     vaultstorage.TestTokenStorage{},
+			tokenStorage:     tokenstorage.TestTokenStorage{},
 			httpClient:       failingHttpClient,
 			kubernetesClient: k8sClient,
 			ttl:              10 * time.Hour,
@@ -212,7 +211,7 @@ func TestMetadataProvider_FetchRepo(t *testing.T) {
 		k8sClient := fake.NewClientBuilder().Build()
 
 		mp := metadataProvider{
-			tokenStorage: vaultstorage.TestTokenStorage{
+			tokenStorage: tokenstorage.TestTokenStorage{
 				GetImpl: func(_ context.Context, _ *api.SPIAccessToken) (*api.Token, error) {
 					// this is the default case, but let's be explicit here
 					return nil, nil
@@ -288,7 +287,7 @@ func TestMetadataProvider_FetchRepo(t *testing.T) {
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(token).Build()
 
 			mp := metadataProvider{
-				tokenStorage: vaultstorage.TestTokenStorage{
+				tokenStorage: tokenstorage.TestTokenStorage{
 					GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 						return &api.Token{
 							AccessToken: "token",
@@ -409,7 +408,7 @@ func TestMetadataProvider_ShouldRecoverFromTokenWithOldStateFormat(t *testing.T)
 			}),
 		}
 		mp := metadataProvider{
-			tokenStorage: vaultstorage.TestTokenStorage{
+			tokenStorage: tokenstorage.TestTokenStorage{
 				GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 					return &api.Token{
 						AccessToken: "token",

--- a/pkg/serviceprovider/quay/quay_test.go
+++ b/pkg/serviceprovider/quay/quay_test.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
@@ -92,7 +92,7 @@ func TestMapToken(t *testing.T) {
 		KubernetesClient: k8sClient,
 		HttpClient:       httpClient,
 		Initializers:     initializers,
-		TokenStorage: vaultstorage.TestTokenStorage{
+		TokenStorage: tokenstorage.TestTokenStorage{
 			GetImpl: func(ctx context.Context, token *api.SPIAccessToken) (*api.Token, error) {
 				return &api.Token{
 					AccessToken: "accessToken",
@@ -368,7 +368,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 			},
 		},
 	}
-	ts := vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+	ts := tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 		return &api.Token{AccessToken: "blabol"}, nil
 	}}
 
@@ -583,7 +583,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusUnauthorized}, nil
 			}},
 			lookup: lookupMock,
-			tokenStorage: vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+			tokenStorage: tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 				return nil, nil
 			}},
 		}
@@ -606,7 +606,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(publicRepoResponseJson))}, nil
 			}},
 			lookup: lookupMock,
-			tokenStorage: vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+			tokenStorage: tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 				return nil, nil
 			}},
 		}
@@ -629,7 +629,7 @@ func TestCheckRepositoryAccess(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusUnauthorized}, nil
 			}},
 			lookup: lookupMock,
-			tokenStorage: vaultstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
+			tokenStorage: tokenstorage.TestTokenStorage{GetImpl: func(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
 				return &api.Token{AccessToken: "tkn", Username: "alois"}, nil
 			}},
 		}

--- a/pkg/serviceprovider/quay/tokenfilter_test.go
+++ b/pkg/serviceprovider/quay/tokenfilter_test.go
@@ -24,7 +24,7 @@ import (
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage/vaultstorage"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/util"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -113,7 +113,7 @@ func TestMatches_RobotToken(t *testing.T) {
 			metadataProvider: &metadataProvider{
 				kubernetesClient: kubernetesClient,
 				httpClient:       httpClient,
-				tokenStorage: vaultstorage.TestTokenStorage{
+				tokenStorage: tokenstorage.TestTokenStorage{
 					StoreImpl: func(ctx context.Context, token *api.SPIAccessToken, token2 *api.Token) error {
 						return nil
 					},

--- a/pkg/spi-shared/tokenstorage/testtokenstorage.go
+++ b/pkg/spi-shared/tokenstorage/testtokenstorage.go
@@ -14,18 +14,10 @@
 
 //go:build !release
 
-package vaultstorage
+package tokenstorage
 
 import (
 	"context"
-
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/vaultstorage"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
-
-	"github.com/hashicorp/vault/vault"
-	vtesting "github.com/mitchellh/go-testing-interface"
 
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 )
@@ -69,27 +61,4 @@ func (t TestTokenStorage) Delete(ctx context.Context, owner *api.SPIAccessToken)
 	return t.DeleteImpl(ctx, owner)
 }
 
-var _ tokenstorage.TokenStorage = (*TestTokenStorage)(nil)
-
-// FIXME: remove this and replace usages with token storage based on secretstorage.memorystorage
-func CreateTestVaultTokenStorage(t vtesting.T) (*vault.TestCluster, tokenstorage.TokenStorage) {
-	t.Helper()
-	cluster, storage := vaultstorage.CreateTestVaultSecretStorage(t)
-	return cluster, &tokenstorage.DefaultTokenStorage{
-		SecretStorage: storage,
-		Serializer:    tokenstorage.JSONSerializer,
-		Deserializer:  tokenstorage.JSONDeserializer,
-	}
-}
-
-// FIXME: remove this and replace usages with the equivalent in secretstorage.vaultstorage (or with the secretstorage.memorystorage)
-func CreateTestVaultTokenStorageWithAuthAndMetrics(t vtesting.T, metricsRegistry *prometheus.Registry) (*vault.TestCluster, tokenstorage.TokenStorage, string, string) {
-	t.Helper()
-	cluster, storage, roleId, secretId := vaultstorage.CreateTestVaultSecretStorageWithAuthAndMetrics(t, metricsRegistry)
-	tokenStorage := &tokenstorage.DefaultTokenStorage{
-		SecretStorage: storage,
-		Serializer:    tokenstorage.JSONSerializer,
-		Deserializer:  tokenstorage.JSONDeserializer,
-	}
-	return cluster, tokenStorage, roleId, secretId
-}
+var _ TokenStorage = (*TestTokenStorage)(nil)


### PR DESCRIPTION
### What does this PR do?
This is basically a clean-up of the codebase after the introduction of the `SecretStorage` abstraction.

* Use the in-memory token storage in integration tests
* Move the TestTokenStorage mockable struct from `vaultstorage` directly into `tokenstorage` package.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-371

### How to test this PR?
This only changing the tests and testing infrastructure so a successful run of `make test` should be enough "proof".