### PR TITLE
Revert "Added ppcle64 support to the Service-provider-integration-operator"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,8 +31,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to docker.io
@@ -64,7 +62,6 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/ppc64le
           tags: ${{ steps.meta_operator.outputs.tags }}
           labels: ${{ steps.meta_operator.outputs.labels }}
           cache-from: type=gha
@@ -85,7 +82,6 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/ppc64le
           tags: ${{ steps.meta_oauth.outputs.tags }}
           labels: ${{ steps.meta_oauth.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Reverts redhat-appstudio/service-provider-integration-operator#511

I look closer at this topic. And I think this change is not enough. Because of https://github.com/redhat-appstudio/service-provider-integration-operator/blob/22804290ba761746e8381f6cd443cc69fd0618d5/Dockerfile#L20  https://github.com/redhat-appstudio/service-provider-integration-operator/blob/22804290ba761746e8381f6cd443cc69fd0618d5/oauth.Dockerfile#L22

also build time take 1h13m instead of 13m