### PR TITLE
don't use anonymous struct as context key

### DIFF
--- a/pkg/spi-shared/config/config.go
+++ b/pkg/spi-shared/config/config.go
@@ -24,7 +24,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var SPIInstanceIdContextKey = struct{}{}
+type spiInstanceIdContextKeyType struct{}
+
+var SPIInstanceIdContextKey = spiInstanceIdContextKeyType{}
 
 type ServiceProviderName string
 type ServiceProviderType struct {

--- a/pkg/spi-shared/httptransport/metrics.go
+++ b/pkg/spi-shared/httptransport/metrics.go
@@ -79,13 +79,15 @@ type HttpMetricCollectingRoundTripper struct {
 
 var _ http.RoundTripper = (*HttpMetricCollectingRoundTripper)(nil)
 
-var metricsCollectorKey = struct{}{}
+type metricsCollectorContextKeyType struct{}
+
+var metricsCollectorContextKey = metricsCollectorContextKeyType{}
 
 // ContextWithMetrics returns a new context based on the supplied one that contains the provided metrics collection
 // configurations. If this context is used to perform an HTTP request with the HttpMetricCollectingRoundTripper, the
 // configured metrics will be collected.
 func ContextWithMetrics(ctx context.Context, cfg *HttpMetricCollectionConfig) context.Context {
-	return context.WithValue(ctx, metricsCollectorKey, cfg)
+	return context.WithValue(ctx, metricsCollectorContextKey, cfg)
 }
 
 // HttpMetricCollectionConfig specifies what metric should be collected.
@@ -96,7 +98,7 @@ type HttpMetricCollectionConfig struct {
 }
 
 func (h HttpMetricCollectingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
-	stored := request.Context().Value(metricsCollectorKey)
+	stored := request.Context().Value(metricsCollectorContextKey)
 	var cfg *HttpMetricCollectionConfig
 
 	if stored != nil {


### PR DESCRIPTION
### What does this PR do?
using anonymous struct as context key is not a good idea because it's not unique type. In this case `metricsCollectorKey` got mixed with `SPIInstanceIdContextKey` and we've got unexpected value. We have to always create a new type for new context keys. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-429

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-533
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-533
```

1. deploy SPI using Vault Token storage with images ^^
2. must start fine (didn't started before the patch)
