### PR TITLE
Clean up the tokenstorage/secretstorage split and introduce TypedSecretStorage

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,8 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/awsstorage/awscli"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/vaultstorage/vaultcli"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 )
 
@@ -35,9 +33,9 @@ func InitTokenStorage(ctx context.Context, args *CommonCliArgs) (tokenstorage.To
 
 	switch args.TokenStorage {
 	case VaultTokenStorage:
-		tokenStorage, errTokenStorage = vaultcli.CreateVaultStorage(ctx, &args.VaultCliArgs)
+		tokenStorage, errTokenStorage = tokenstorage.NewVaultStorage(ctx, &args.VaultCliArgs)
 	case AWSTokenStorage:
-		tokenStorage, errTokenStorage = awscli.NewAwsTokenStorage(ctx, &args.AWSCliArgs)
+		tokenStorage, errTokenStorage = tokenstorage.NewAwsTokenStorage(ctx, &args.AWSCliArgs)
 	default:
 		return nil, fmt.Errorf("%w '%s'", errUnsupportedTokenStorage, args.TokenStorage)
 	}

--- a/integration_tests/tokenstorage_acceptance_test.go
+++ b/integration_tests/tokenstorage_acceptance_test.go
@@ -82,7 +82,7 @@ func TestAws(t *testing.T) {
 		return
 	}
 
-	storage, error := awscli.NewAwsTokenStorage(ctx, &awscli.AWSCliArgs{
+	storage, error := tokenstorage.NewAwsTokenStorage(ctx, &awscli.AWSCliArgs{
 		ConfigFile:      awsConfig,
 		CredentialsFile: awsCreds,
 	})
@@ -96,11 +96,7 @@ func TestAws(t *testing.T) {
 }
 
 func createTokenStorage(secretStorage secretstorage.SecretStorage) tokenstorage.TokenStorage {
-	return &tokenstorage.DefaultTokenStorage{
-		SecretStorage: secretStorage,
-		Serializer:    tokenstorage.JSONSerializer,
-		Deserializer:  tokenstorage.JSONDeserializer,
-	}
+	return tokenstorage.NewJSONSerializingTokenStorage(secretStorage)
 }
 
 func testStorage(t *testing.T, ctx context.Context, storage tokenstorage.TokenStorage) {

--- a/pkg/spi-shared/secretstorage/awsstorage/awscli/cli.go
+++ b/pkg/spi-shared/secretstorage/awsstorage/awscli/cli.go
@@ -24,8 +24,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/smithy-go/logging"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/awsstorage"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -38,21 +38,15 @@ var (
 	errInvalidCliArgs = errors.New("invalid cli args")
 )
 
-func NewAwsTokenStorage(ctx context.Context, args *AWSCliArgs) (tokenstorage.TokenStorage, error) {
+func NewAwsSecretStorage(ctx context.Context, args *AWSCliArgs) (secretstorage.SecretStorage, error) {
 	log.FromContext(ctx).Info("creating aws client")
 	cfg, err := configFromCliArgs(ctx, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AWS secretmanager configuration: %w", err)
 	}
 
-	secretStorage := &awsstorage.AwsSecretStorage{
+	return &awsstorage.AwsSecretStorage{
 		Config: cfg,
-	}
-
-	return &tokenstorage.DefaultTokenStorage{
-		SecretStorage: secretStorage,
-		Serializer:    tokenstorage.JSONSerializer,
-		Deserializer:  tokenstorage.JSONDeserializer,
 	}, nil
 }
 

--- a/pkg/spi-shared/secretstorage/awsstorage/awscli/cli_test.go
+++ b/pkg/spi-shared/secretstorage/awsstorage/awscli/cli_test.go
@@ -25,20 +25,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewAwsTokenStorage(t *testing.T) {
+func TestNewAwsSecretStorage(t *testing.T) {
 	configFile := createFile(t, "awsconfig", "")
 	defer os.Remove(configFile)
 	credsFile := createFile(t, "awscreds", "")
 	defer os.Remove(credsFile)
 
-	storage, err := NewAwsTokenStorage(context.TODO(), &AWSCliArgs{ConfigFile: configFile, CredentialsFile: credsFile})
+	storage, err := NewAwsSecretStorage(context.TODO(), &AWSCliArgs{ConfigFile: configFile, CredentialsFile: credsFile})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, storage)
 }
 
-func TestNewAwsTokenStorageWithInvalidConfig(t *testing.T) {
-	storage, err := NewAwsTokenStorage(context.TODO(), &AWSCliArgs{})
+func TestNewAwsSecretStorageWithInvalidConfig(t *testing.T) {
+	storage, err := NewAwsSecretStorage(context.TODO(), &AWSCliArgs{})
 
 	assert.Error(t, err)
 	assert.Nil(t, storage)

--- a/pkg/spi-shared/secretstorage/secretstorage.go
+++ b/pkg/spi-shared/secretstorage/secretstorage.go
@@ -16,8 +16,11 @@ package secretstorage
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // SecretID is a generic identifier of the secret that we store data of. While it very
@@ -46,4 +49,113 @@ type SecretStorage interface {
 	Get(ctx context.Context, id SecretID) ([]byte, error)
 	// Delete deletes the data of given id. A NotFoundError is returned if there is no such data.
 	Delete(ctx context.Context, id SecretID) error
+}
+
+// TypedSecretStorage is a generic "companion" to the "raw" SecretStorage interface which uses
+// strongly typed arguments instead of the generic SecretID and []byte.
+type TypedSecretStorage[ID any, D any] interface {
+	// Initialize initializes the connection to the underlying data store, etc.
+	Initialize(ctx context.Context) error
+	// Store stores the provided data under given id
+	Store(ctx context.Context, id *ID, data *D) error
+	// Get retrieves the data under the given id. A NotFoundError is returned if the data is not found.
+	Get(ctx context.Context, id *ID) (*D, error)
+	// Delete deletes the data of given id. A NotFoundError is returned if there is no such data.
+	Delete(ctx context.Context, id *ID) error
+}
+
+// DefaultTypedSecretStorate is the default implementation of the TypedSecretStorage interface
+// that uses the provided functions to convert between the id and data types to SecretID and []byte
+// respectively.
+type DefaultTypedSecretStorate[ID any, D any] struct {
+	// DataTypeName is the human-readable name of the data type that is being stored. This is used
+	// in error messages.
+	DataTypeName string
+
+	// SecretStorage is the underlying secret storage used for the actual operations against the persistent
+	// storage.
+	SecretStorage SecretStorage
+
+	// ToID is a function that converts the strongly typed ID to the generic SecretID used by the SecretStorage.
+	ToID func(*ID) SecretID
+
+	// Serialize is a function to convert the strongly type data into a byte array. You can use
+	// for example the SerializeJSON function.
+	Serialize func(*D) ([]byte, error)
+
+	// Deserialize is a function to convert the byte array back to the strongly type data. You can use
+	// for example the DeserializeJSON function.
+	Deserialize func([]byte, *D) error
+}
+
+// ObjectToID converts given Kubernetes object to SecretID based on the name and namespace.
+func ObjectToID[O client.Object](obj O) SecretID {
+	return SecretID{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+}
+
+// SerializeJSON is a thin wrapper around Marshal function of encoding/json.
+func SerializeJSON[D any](obj *D) ([]byte, error) {
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize data: %w", err)
+	}
+	return bytes, nil
+}
+
+// DeserializeJSON is a thin wrapper around Unmarshal function of encoding/json.
+func DeserializeJSON[D any](data []byte, obj *D) error {
+	if err := json.Unmarshal(data, obj); err != nil {
+		return fmt.Errorf("failed to deserialize the data: %w", err)
+	}
+	return nil
+}
+
+var _ TypedSecretStorage[string, string] = (*DefaultTypedSecretStorate[string, string])(nil)
+
+// Delete implements TypedSecretStorage
+func (s *DefaultTypedSecretStorate[ID, D]) Delete(ctx context.Context, id *ID) error {
+	if err := s.SecretStorage.Delete(ctx, s.ToID(id)); err != nil {
+		return fmt.Errorf("failed to delete %s: %w", s.DataTypeName, err)
+	}
+	return nil
+}
+
+// Get implements TypedSecretStorage
+func (s *DefaultTypedSecretStorate[ID, D]) Get(ctx context.Context, id *ID) (*D, error) {
+	d, err := s.SecretStorage.Get(ctx, s.ToID(id))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the %s: %w", s.DataTypeName, err)
+	}
+
+	var parsed D
+	if err := s.Deserialize(d, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to deserialize the data to %s: %w", s.DataTypeName, err)
+	}
+	return &parsed, nil
+}
+
+// Initialize implements TypedSecretStorage
+func (s *DefaultTypedSecretStorate[ID, D]) Initialize(ctx context.Context) error {
+	if err := s.SecretStorage.Initialize(ctx); err != nil {
+		return fmt.Errorf("underlying secret storage failed to initialize: %w", err)
+	}
+	return nil
+}
+
+// Store implements TypedSecretStorage
+func (s *DefaultTypedSecretStorate[ID, D]) Store(ctx context.Context, id *ID, data *D) error {
+	secretId := s.ToID(id)
+	bytes, err := s.Serialize(data)
+	if err != nil {
+		return fmt.Errorf("failed to serialize the %s for storage: %w", s.DataTypeName, err)
+	}
+
+	if err = s.SecretStorage.Store(ctx, secretId, bytes); err != nil {
+		return fmt.Errorf("failed to store %s: %w", s.DataTypeName, err)
+	}
+
+	return nil
 }

--- a/pkg/spi-shared/secretstorage/secretstorage.go
+++ b/pkg/spi-shared/secretstorage/secretstorage.go
@@ -64,10 +64,10 @@ type TypedSecretStorage[ID any, D any] interface {
 	Delete(ctx context.Context, id *ID) error
 }
 
-// DefaultTypedSecretStorate is the default implementation of the TypedSecretStorage interface
+// DefaultTypedSecretStorage is the default implementation of the TypedSecretStorage interface
 // that uses the provided functions to convert between the id and data types to SecretID and []byte
 // respectively.
-type DefaultTypedSecretStorate[ID any, D any] struct {
+type DefaultTypedSecretStorage[ID any, D any] struct {
 	// DataTypeName is the human-readable name of the data type that is being stored. This is used
 	// in error messages.
 	DataTypeName string
@@ -113,10 +113,10 @@ func DeserializeJSON[D any](data []byte, obj *D) error {
 	return nil
 }
 
-var _ TypedSecretStorage[string, string] = (*DefaultTypedSecretStorate[string, string])(nil)
+var _ TypedSecretStorage[string, string] = (*DefaultTypedSecretStorage[string, string])(nil)
 
 // Delete implements TypedSecretStorage
-func (s *DefaultTypedSecretStorate[ID, D]) Delete(ctx context.Context, id *ID) error {
+func (s *DefaultTypedSecretStorage[ID, D]) Delete(ctx context.Context, id *ID) error {
 	if err := s.SecretStorage.Delete(ctx, s.ToID(id)); err != nil {
 		return fmt.Errorf("failed to delete %s: %w", s.DataTypeName, err)
 	}
@@ -124,7 +124,7 @@ func (s *DefaultTypedSecretStorate[ID, D]) Delete(ctx context.Context, id *ID) e
 }
 
 // Get implements TypedSecretStorage
-func (s *DefaultTypedSecretStorate[ID, D]) Get(ctx context.Context, id *ID) (*D, error) {
+func (s *DefaultTypedSecretStorage[ID, D]) Get(ctx context.Context, id *ID) (*D, error) {
 	d, err := s.SecretStorage.Get(ctx, s.ToID(id))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the %s: %w", s.DataTypeName, err)
@@ -138,7 +138,7 @@ func (s *DefaultTypedSecretStorate[ID, D]) Get(ctx context.Context, id *ID) (*D,
 }
 
 // Initialize implements TypedSecretStorage
-func (s *DefaultTypedSecretStorate[ID, D]) Initialize(ctx context.Context) error {
+func (s *DefaultTypedSecretStorage[ID, D]) Initialize(ctx context.Context) error {
 	if err := s.SecretStorage.Initialize(ctx); err != nil {
 		return fmt.Errorf("underlying secret storage failed to initialize: %w", err)
 	}
@@ -146,7 +146,7 @@ func (s *DefaultTypedSecretStorate[ID, D]) Initialize(ctx context.Context) error
 }
 
 // Store implements TypedSecretStorage
-func (s *DefaultTypedSecretStorate[ID, D]) Store(ctx context.Context, id *ID, data *D) error {
+func (s *DefaultTypedSecretStorage[ID, D]) Store(ctx context.Context, id *ID, data *D) error {
 	secretId := s.ToID(id)
 	bytes, err := s.Serialize(data)
 	if err != nil {

--- a/pkg/spi-shared/secretstorage/secretstorage_test.go
+++ b/pkg/spi-shared/secretstorage/secretstorage_test.go
@@ -1,0 +1,148 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretstorage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
+)
+
+func TestDefaultTypedSecretStorage_Store(t *testing.T) {
+	record := testStorageCall(func(dtss *DefaultTypedSecretStorage[bool, bool]) {
+		dtss.Store(context.TODO(), pointer.Bool(true), nil)
+	})
+
+	assert.True(t, record.ToIDCalled)
+	assert.True(t, record.SerializeCalled)
+	assert.True(t, record.StoreCalled)
+
+	assert.False(t, record.DeserializeCalled)
+	assert.False(t, record.GetCalled)
+	assert.False(t, record.DeleteCalled)
+	assert.False(t, record.InitializeCalled)
+}
+
+func TestDefaultTypedSecretStorage_Get(t *testing.T) {
+	record := testStorageCall(func(dtss *DefaultTypedSecretStorage[int, bool]) {
+		dtss.Get(context.TODO(), pointer.Int(42))
+	})
+
+	assert.True(t, record.ToIDCalled)
+	assert.True(t, record.GetCalled)
+	assert.True(t, record.DeserializeCalled)
+
+	assert.False(t, record.StoreCalled)
+	assert.False(t, record.SerializeCalled)
+	assert.False(t, record.DeleteCalled)
+	assert.False(t, record.InitializeCalled)
+}
+
+func TestDefaultTypedSecretStorage_Delete(t *testing.T) {
+	record := testStorageCall(func(dtss *DefaultTypedSecretStorage[int, bool]) {
+		dtss.Delete(context.TODO(), pointer.Int(42))
+	})
+
+	assert.True(t, record.ToIDCalled)
+	assert.True(t, record.DeleteCalled)
+
+	assert.False(t, record.GetCalled)
+	assert.False(t, record.DeserializeCalled)
+	assert.False(t, record.StoreCalled)
+	assert.False(t, record.SerializeCalled)
+	assert.False(t, record.InitializeCalled)
+}
+
+func TestDefaultTypedSecretStorage_Initialize(t *testing.T) {
+	record := testStorageCall(func(dtss *DefaultTypedSecretStorage[int, bool]) {
+		dtss.Initialize(context.TODO())
+	})
+
+	assert.True(t, record.InitializeCalled)
+
+	assert.False(t, record.ToIDCalled)
+	assert.False(t, record.DeleteCalled)
+	assert.False(t, record.GetCalled)
+	assert.False(t, record.DeserializeCalled)
+	assert.False(t, record.StoreCalled)
+	assert.False(t, record.SerializeCalled)
+}
+
+func TestSerializeJSON(t *testing.T) {
+	data, err := SerializeJSON(pointer.Bool(true))
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("true"), data)
+}
+
+func TestDeserializeJSON(t *testing.T) {
+	data := []byte("42")
+	val := pointer.Int(0)
+	assert.NoError(t, DeserializeJSON(data, val))
+	assert.Equal(t, 42, *val)
+}
+
+type CallsRecord struct {
+	ToIDCalled        bool
+	SerializeCalled   bool
+	DeserializeCalled bool
+	StoreCalled       bool
+	GetCalled         bool
+	DeleteCalled      bool
+	InitializeCalled  bool
+}
+
+func testStorageCall[K any, D any](test func(*DefaultTypedSecretStorage[K, D])) CallsRecord {
+	record := CallsRecord{}
+
+	instance := DefaultTypedSecretStorage[K, D]{
+		DataTypeName: "kachny",
+		SecretStorage: &TestSecretStorage{
+			InitializeImpl: func(_ context.Context) error {
+				record.InitializeCalled = true
+				return nil
+			},
+			StoreImpl: func(_ context.Context, _ SecretID, _ []byte) error {
+				record.StoreCalled = true
+				return nil
+			},
+			GetImpl: func(_ context.Context, _ SecretID) ([]byte, error) {
+				record.GetCalled = true
+				return nil, nil
+			},
+			DeleteImpl: func(_ context.Context, _ SecretID) error {
+				record.DeleteCalled = true
+				return nil
+			},
+		},
+		ToID: func(i *K) SecretID {
+			record.ToIDCalled = true
+			return SecretID{}
+		},
+		Serialize: func(d *D) ([]byte, error) {
+			record.SerializeCalled = true
+			return nil, nil
+		},
+		Deserialize: func(b []byte, d *D) error {
+			record.DeserializeCalled = true
+			return nil
+		},
+	}
+
+	test(&instance)
+
+	return record
+}

--- a/pkg/spi-shared/secretstorage/testsecretstorage.go
+++ b/pkg/spi-shared/secretstorage/testsecretstorage.go
@@ -1,0 +1,62 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !release
+
+package secretstorage
+
+import (
+	"context"
+)
+
+type TestSecretStorage struct {
+	InitializeImpl func(context.Context) error
+	StoreImpl      func(ctx context.Context, key SecretID, data []byte) error
+	GetImpl        func(ctx context.Context, key SecretID) ([]byte, error)
+	DeleteImpl     func(ctx context.Context, key SecretID) error
+}
+
+func (t TestSecretStorage) Initialize(ctx context.Context) error {
+	if t.InitializeImpl == nil {
+		return nil
+	}
+
+	return t.InitializeImpl(ctx)
+}
+
+func (t TestSecretStorage) Store(ctx context.Context, key SecretID, data []byte) error {
+	if t.StoreImpl == nil {
+		return nil
+	}
+
+	return t.StoreImpl(ctx, key, data)
+}
+
+func (t TestSecretStorage) Get(ctx context.Context, key SecretID) ([]byte, error) {
+	if t.GetImpl == nil {
+		return nil, nil
+	}
+
+	return t.GetImpl(ctx, key)
+}
+
+func (t TestSecretStorage) Delete(ctx context.Context, key SecretID) error {
+	if t.DeleteImpl == nil {
+		return nil
+	}
+
+	return t.DeleteImpl(ctx, key)
+}
+
+var _ SecretStorage = (*TestSecretStorage)(nil)

--- a/pkg/spi-shared/secretstorage/vaultstorage/vaultcli/cli.go
+++ b/pkg/spi-shared/secretstorage/vaultstorage/vaultcli/cli.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/vaultstorage"
-	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -50,16 +50,12 @@ func VaultStorageConfigFromCliArgs(args *VaultCliArgs) *vaultstorage.VaultStorag
 	}
 }
 
-func CreateVaultStorage(ctx context.Context, args *VaultCliArgs) (tokenstorage.TokenStorage, error) {
+func CreateVaultStorage(ctx context.Context, args *VaultCliArgs) (secretstorage.SecretStorage, error) {
 	vaultConfig := VaultStorageConfigFromCliArgs(args)
 	// use the same metrics registry as the controller-runtime
 	vaultConfig.MetricsRegisterer = metrics.Registry
 
-	return &tokenstorage.DefaultTokenStorage{
-		SecretStorage: &vaultstorage.VaultSecretStorage{
-			Config: vaultConfig,
-		},
-		Serializer:   tokenstorage.JSONSerializer,
-		Deserializer: tokenstorage.JSONDeserializer,
+	return &vaultstorage.VaultSecretStorage{
+		Config: vaultConfig,
 	}, nil
 }

--- a/pkg/spi-shared/tokenstorage/aws.go
+++ b/pkg/spi-shared/tokenstorage/aws.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenstorage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/awsstorage/awscli"
+)
+
+func NewAwsTokenStorage(ctx context.Context, args *awscli.AWSCliArgs) (TokenStorage, error) {
+	secretStorage, err := awscli.NewAwsSecretStorage(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct AWS secret storage: %w", err)
+	}
+
+	return NewJSONSerializingTokenStorage(secretStorage), nil
+}

--- a/pkg/spi-shared/tokenstorage/tokenstorage.go
+++ b/pkg/spi-shared/tokenstorage/tokenstorage.go
@@ -38,7 +38,7 @@ type TokenStorage interface {
 // The returned object is an instance of DefaultTokenStorage.
 func NewJSONSerializingTokenStorage(secretStorage secretstorage.SecretStorage) TokenStorage {
 	return &DefaultTokenStorage{
-		SecretStorage: &secretstorage.DefaultTypedSecretStorate[api.SPIAccessToken, api.Token]{
+		SecretStorage: &secretstorage.DefaultTypedSecretStorage[api.SPIAccessToken, api.Token]{
 			DataTypeName:  "token",
 			SecretStorage: secretStorage,
 			ToID:          secretstorage.ObjectToID[*api.SPIAccessToken],

--- a/pkg/spi-shared/tokenstorage/tokenstorage.go
+++ b/pkg/spi-shared/tokenstorage/tokenstorage.go
@@ -16,7 +16,6 @@ package tokenstorage
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -24,8 +23,9 @@ import (
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage"
 )
 
-// TokenStorage is a simple interface on top of Kubernetes client to perform CRUD operations on the tokens. This is done
-// so that we can provide either secret-based or Vault-based implementation.
+// TokenStorage is an interface similar to SecretStorage that has historically been used to work with tokens.
+// New storage types are built on top of secretstorage.TypedSecretStorage that provides the same interface
+// generically.
 type TokenStorage interface {
 	Initialize(ctx context.Context) error
 	Store(ctx context.Context, owner *api.SPIAccessToken, token *api.Token) error
@@ -33,37 +33,33 @@ type TokenStorage interface {
 	Delete(ctx context.Context, owner *api.SPIAccessToken) error
 }
 
+// NewJSONSerializingTokenStorage is a convenience function to construct a TokenStorage instance
+// based on the provided SecretStorage and serializing the data to JSON for persistence.
+// The returned object is an instance of DefaultTokenStorage.
+func NewJSONSerializingTokenStorage(secretStorage secretstorage.SecretStorage) TokenStorage {
+	return &DefaultTokenStorage{
+		SecretStorage: &secretstorage.DefaultTypedSecretStorate[api.SPIAccessToken, api.Token]{
+			DataTypeName:  "token",
+			SecretStorage: secretStorage,
+			ToID:          secretstorage.ObjectToID[*api.SPIAccessToken],
+			Serialize:     secretstorage.SerializeJSON[api.Token],
+			Deserialize:   secretstorage.DeserializeJSON[api.Token],
+		},
+	}
+}
+
 // DefaultTokenStorage is the default implementation of the TokenStorage interface that uses the underlying SecretStorage
 // for actually storing the data.
+// It honors the original behavior of the TokenStorage interface that used to return nil instead
+// of throwing NotFoundError when encountering non-existent records in Get and Delete.
 type DefaultTokenStorage struct {
 	// SecretStorage is the underlying storage that handled the storing of the tokens
-	SecretStorage secretstorage.SecretStorage
-	// Serializer is a function to turn the tokens into byte arrays. You can use JSONSerializer if it fits your purpose.
-	Serializer func(*api.Token) ([]byte, error)
-	// Deserializer is a function to turn byte arrays back into token objects. You can use JSONDeserializer if it fits your purpose.
-	Deserializer func([]byte, *api.Token) error
-}
-
-// JSONSerializer is a thin wrapper around Marshal function of encoding/json.
-func JSONSerializer(token *api.Token) ([]byte, error) {
-	bytes, err := json.Marshal(token)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize token data: %w", err)
-	}
-	return bytes, nil
-}
-
-// JSONDeserializer is a thin wrapper around Unmarshal function of encoding/json.
-func JSONDeserializer(data []byte, token *api.Token) error {
-	if err := json.Unmarshal(data, token); err != nil {
-		return fmt.Errorf("failed to deserialize token data: %w", err)
-	}
-	return nil
+	SecretStorage secretstorage.TypedSecretStorage[api.SPIAccessToken, api.Token]
 }
 
 // Delete implements TokenStorage
 func (s *DefaultTokenStorage) Delete(ctx context.Context, owner *api.SPIAccessToken) error {
-	if err := s.SecretStorage.Delete(ctx, toSecretID(owner)); err != nil && errors.Is(err, secretstorage.NotFoundError) {
+	if err := s.SecretStorage.Delete(ctx, owner); err != nil && errors.Is(err, secretstorage.NotFoundError) {
 		return fmt.Errorf("failed to delete the token data: %w", err)
 	}
 	return nil
@@ -71,16 +67,11 @@ func (s *DefaultTokenStorage) Delete(ctx context.Context, owner *api.SPIAccessTo
 
 // Get implements TokenStorage
 func (s *DefaultTokenStorage) Get(ctx context.Context, owner *api.SPIAccessToken) (*api.Token, error) {
-	data, err := s.SecretStorage.Get(ctx, toSecretID(owner))
+	t, err := s.SecretStorage.Get(ctx, owner)
 	if errors.Is(err, secretstorage.NotFoundError) {
 		return nil, nil
 	} else if err != nil {
 		return nil, fmt.Errorf("failed to get the token data: %w", err)
-	}
-
-	t, err := s.toToken(data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to deserialize the token data: %w", err)
 	}
 
 	return t, nil
@@ -97,41 +88,11 @@ func (s *DefaultTokenStorage) Initialize(ctx context.Context) error {
 
 // Store implements TokenStorage
 func (s *DefaultTokenStorage) Store(ctx context.Context, owner *api.SPIAccessToken, token *api.Token) error {
-	data, err := s.toData(token)
-	if err != nil {
-		return fmt.Errorf("failed to serialize the token data: %w", err)
-	}
-
-	if err = s.SecretStorage.Store(ctx, toSecretID(owner), data); err != nil {
+	if err := s.SecretStorage.Store(ctx, owner, token); err != nil {
 		return fmt.Errorf("failed to store the token data: %w", err)
 	}
 
 	return nil
 }
 
-func (s *DefaultTokenStorage) toToken(data []byte) (*api.Token, error) {
-	token := &api.Token{}
-	if err := s.Deserializer(data, token); err != nil {
-		return nil, fmt.Errorf("failed to deserialize the data to api.Token: %w", err)
-	}
-
-	return token, nil
-}
-
-func (s *DefaultTokenStorage) toData(t *api.Token) ([]byte, error) {
-	data, err := s.Serializer(t)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize the api.Token: %w", err)
-	}
-
-	return data, nil
-}
-
 var _ TokenStorage = (*DefaultTokenStorage)(nil)
-
-func toSecretID(t *api.SPIAccessToken) secretstorage.SecretID {
-	return secretstorage.SecretID{
-		Name:      t.Name,
-		Namespace: t.Namespace,
-	}
-}

--- a/pkg/spi-shared/tokenstorage/vault.go
+++ b/pkg/spi-shared/tokenstorage/vault.go
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenstorage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/secretstorage/vaultstorage/vaultcli"
+)
+
+func NewVaultStorage(ctx context.Context, args *vaultcli.VaultCliArgs) (TokenStorage, error) {
+	secretStorage, err := vaultcli.CreateVaultStorage(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct the secret storage: %w", err)
+	}
+	return NewJSONSerializingTokenStorage(secretStorage), nil
+}


### PR DESCRIPTION
### What does this PR do?
Clean up the tokenstorage/secretstorage split and introduce TypedSecretStorage to aid in adding new storage types in the future.

### What issues does this PR fix or reference?
none

### How to test this PR?
no changes in behavior should be apparent.
```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
