### PR TITLE
Binding controller must react to token data change as well

### DIFF
--- a/controllers/spiaccesstokenbinding_controller.go
+++ b/controllers/spiaccesstokenbinding_controller.go
@@ -121,6 +121,25 @@ func (r *SPIAccessTokenBindingReconciler) SetupWithManager(mgr ctrl.Manager) err
 
 			return requests
 		})).
+		Watches(&source.Kind{Type: &api.SPIAccessTokenDataUpdate{}}, handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
+			requests, err := r.filteredBindingsAsRequests(context.Background(), o.GetNamespace(), func(binding api.SPIAccessTokenBinding) bool {
+				dataUpdate, ok := o.(*api.SPIAccessTokenDataUpdate)
+				if !ok {
+					return false
+				}
+				return binding.Status.LinkedAccessTokenName == dataUpdate.Spec.TokenName
+
+			})
+			if err != nil {
+				enqueueLog.Error(err, "failed to list SPIAccessTokenBindings while determining the ones linked to DataUpdate",
+					"SecretName", o.GetName(), "SecretNamespace", o.GetNamespace())
+				return []reconcile.Request{}
+			}
+
+			logReconciliationRequests(requests, "SPIAccessTokenBinding", o, "Secret")
+
+			return requests
+		})).
 		Watches(&source.Kind{Type: &corev1.ServiceAccount{}}, handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
 			requests, err := r.filteredBindingsAsRequests(context.Background(), o.GetNamespace(), func(binding api.SPIAccessTokenBinding) bool {
 				return bindings.BindingNameInAnnotation(o.GetAnnotations()[bindings.LinkAnnotation], binding.Name)

--- a/integration_tests/spiaccessbindingcontroller_test.go
+++ b/integration_tests/spiaccessbindingcontroller_test.go
@@ -484,7 +484,7 @@ var _ = Describe("SPIAccessTokenBinding", func() {
 					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: binding.Status.SyncedObjectRef.Name, Namespace: binding.Namespace}, secret)).To(Succeed())
 					secret.Data["password"] = []byte("wrong")
 					g.Expect(ITest.Client.Update(ITest.Context, secret)).To(Succeed())
-				})
+				}).Should(Succeed())
 
 				By("waiting for the secret data to be reverted back to the correct values")
 				testSetup.ReconcileWithCluster(func(g Gomega) {
@@ -493,6 +493,22 @@ var _ = Describe("SPIAccessTokenBinding", func() {
 					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: binding.Status.SyncedObjectRef.Name, Namespace: binding.Namespace}, secret)).To(Succeed())
 					g.Expect(string(secret.Data["password"])).To(Equal("access"))
 				})
+
+				By("changing token data")
+				err = ITest.TokenStorage.Store(ITest.Context, testSetup.InCluster.Tokens[0], &api.Token{
+					AccessToken:  "access-new",
+					RefreshToken: "refresh",
+					TokenType:    "awesome",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("waiting for the secret data to be updated to the correct values")
+				Eventually(func(g Gomega) {
+					binding := testSetup.InCluster.Bindings[0]
+					secret := &corev1.Secret{}
+					g.Expect(ITest.Client.Get(ITest.Context, client.ObjectKey{Name: binding.Status.SyncedObjectRef.Name, Namespace: binding.Namespace}, secret)).To(Succeed())
+					g.Expect(string(secret.Data["password"])).To(Equal("access-new"))
+				}).Should(Succeed())
 			})
 		})
 


### PR DESCRIPTION
### What does this PR do?

If token data is changed,  it must be reflected by the linked secret.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-441

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
 
 - upload token data by secret
 - create binding, check `spi-binding-secret....` is created
 - upload changed token by secret again
 - verify token in `spi-binding-secret....`  is changed as well

```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
