### PR TITLE
(vault-init.sh) removing a bug where the exit command is ingnored because of if statement

### DIFF
--- a/hack/vault-init.sh
+++ b/hack/vault-init.sh
@@ -98,9 +98,9 @@ function generateRootToken() {
   echo "generating root token ..."
 
   vaultExec "vault operator generate-root -cancel" > /dev/null
-  INIT_STATE=$( vaultExec "vault operator generate-root -init -format=yaml" )
-  NONCE=$( echo "${INIT_STATE}" | grep "nonce:" | awk '{split($0,a,": "); print a[2]}' )
-  OTP=$( echo "${INIT_STATE}" | grep "otp:" | awk '{split($0,a,": "); print a[2]}' )
+  INIT=$( vaultExec "vault operator generate-root -init -format=yaml" )
+  NONCE=$( echo "${INIT}" | grep "nonce:" | awk '{split($0,a,": "); print a[2]}' )
+  OTP=$( echo "${INIT}" | grep "otp:" | awk '{split($0,a,": "); print a[2]}' )
 
   KEYI=1
   COMPLETE="false"


### PR DESCRIPTION
### What does this PR do?
I had to recreate the PR because for some reason the old one did not react to changes in branch.

In the isInitialized() function if vault does not respond with expected response the whole bash script should exit. But because the function is run in if statement the "exit 1" is ignored and the echo "failed to obtain initialized status" is consumed and not printed out. 

This PR fixes that.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-375

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

There are three test cases to test:

1. Running in clean environment: this can be through `make deploy_minikube`
2. Running in initialized environment: run `hack/vault-init.sh` on previously deployed deployment.
3. Running in error state:
For this we need to "break" the vault pod. Run the following:
```shell
minikube ssh
cd /tmp/hostpath-provisioner/spi-vault/data-vault-0/
sudo su
chmod -rwx core
exit
```
then restart vault pod and run `hack/vault-init.sh`, you should see output similar to this:
```
failed to obtain initialization status; vault may be in an irrecoverable error state
vault status output: Error checking seal status: Get "http://127.0.0.1:8200/v1/sys/seal-status": dial tcp 127.0.0.1:8200: connect: connection refused
```


```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
