### PR TITLE
ensure binding and filecontentrequest with custom github url match correct token

### DIFF
--- a/pkg/serviceprovider/github/downloadfilecapability.go
+++ b/pkg/serviceprovider/github/downloadfilecapability.go
@@ -49,7 +49,7 @@ var (
 func NewDownloadFileCapability(httpClient *http.Client, ghClientBuilder githubClientBuilder, baseUrl string) (serviceprovider.DownloadFileCapability, error) {
 	reg, err := regexp.Compile(`(?Um)^` + regexp.QuoteMeta(baseUrl) + `/(?P<owner>[^/]+)/(?P<repo>[^/]+)(/|(.git)?)$`)
 	if err != nil {
-		return nil, fmt.Errorf("compliling repoUrl matching regex for GitHub baseUrl %s caused error: %w", baseUrl, err)
+		return nil, fmt.Errorf("compliling repoUrl matching regex for GitHub baseUrl %s failed with error: %w", baseUrl, err)
 	}
 
 	return downloadFileCapability{
@@ -63,7 +63,7 @@ func NewDownloadFileCapability(httpClient *http.Client, ghClientBuilder githubCl
 func (d downloadFileCapability) DownloadFile(ctx context.Context, repoUrl, filepath, ref string, token *api.SPIAccessToken, maxFileSizeLimit int) (string, error) {
 	owner, repo, err := d.parseOwnerAndRepoFromUrl(ctx, repoUrl)
 	if err != nil {
-		return "", fmt.Errorf("could not complile regex to check repoURl: %w", err)
+		return "", fmt.Errorf("could not parse repostitory name and owner from repoUrl: %w", err)
 	}
 	lg := log.FromContext(ctx)
 	ghClient, err := d.ghClientBuilder.createAuthenticatedGhClient(ctx, token)
@@ -95,7 +95,7 @@ func (d downloadFileCapability) parseOwnerAndRepoFromUrl(ctx context.Context, ur
 	urlRegexpNames := d.ghUrlRegexp.SubexpNames()
 	matches := d.ghUrlRegexp.FindAllStringSubmatch(url, -1)
 	if len(matches) == 0 {
-		return "", "", fmt.Errorf("failed to match github repository: %w", unexpectedRepoUrlError)
+		return "", "", fmt.Errorf("failed to match github repository with baseUrl %s: %w", d.ghBaseUrl, unexpectedRepoUrlError)
 	}
 
 	matchesMap := map[string]string{}

--- a/pkg/serviceprovider/github/downloadfilecapability_test.go
+++ b/pkg/serviceprovider/github/downloadfilecapability_test.go
@@ -67,7 +67,9 @@ func TestGetFileHead(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
+	fileCapability, capabilityErr := NewDownloadFileCapability(client, githubClientBuilder, "https://github.com")
+	assert.NoError(t, capabilityErr)
+
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "HEAD", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -115,7 +117,9 @@ func TestGetFileHeadGitSuffix(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
+	fileCapability, capabilityErr := NewDownloadFileCapability(client, githubClientBuilder, "https://github.com")
+	assert.NoError(t, capabilityErr)
+
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo.git", "myfile", "HEAD", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -162,7 +166,9 @@ func TestGetFileOnBranch(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
+	fileCapability, capabilityErr := NewDownloadFileCapability(client, githubClientBuilder, "https://github.com")
+	assert.NoError(t, capabilityErr)
+
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "v0.1.0", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -211,7 +217,9 @@ func TestGetFileOnCommitId(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
+	fileCapability, capabilityErr := NewDownloadFileCapability(client, githubClientBuilder, "https://github.com")
+	assert.NoError(t, capabilityErr)
+
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -249,7 +257,9 @@ func TestGetUnexistingFile(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
+	fileCapability, capabilityErr := NewDownloadFileCapability(&http.Client{}, githubClientBuilder, "https://github.com")
+	assert.NoError(t, capabilityErr)
+
 	_, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", &api.SPIAccessToken{}, 1024)
 	if err == nil {
 		t.Error("error expected")
@@ -259,7 +269,10 @@ func TestGetUnexistingFile(t *testing.T) {
 
 func TestInvalidRepoUrl(t *testing.T) {
 	test := func(t *testing.T, repoUrl string) {
-		fileCapability := downloadFileCapability{&http.Client{}, githubClientBuilder{}, "https://github.com"}
+
+		fileCapability, err := NewDownloadFileCapability(&http.Client{}, githubClientBuilder{}, "https://github.com")
+		assert.NoError(t, err)
+
 		c, err := fileCapability.DownloadFile(context.TODO(), repoUrl, "myfile", "bla", &api.SPIAccessToken{}, 1024)
 
 		assert.Error(t, err)
@@ -274,16 +287,20 @@ func TestInvalidRepoUrl(t *testing.T) {
 }
 
 func TestParseOwnerAndRepoFromUrl(t *testing.T) {
-	fileCapability := downloadFileCapability{&http.Client{}, githubClientBuilder{}, "https://github.com"}
+	downloadCapability, err := NewDownloadFileCapability(&http.Client{}, githubClientBuilder{},
+		"https://github.com")
+	assert.NoError(t, err)
+	ghCapability := downloadCapability.(downloadFileCapability)
+
 	testSuccess := func(t *testing.T, repoUrl, expectedOwner, expectedRepo string) {
-		owner, repo, err := fileCapability.parseOwnerAndRepoFromUrl(context.TODO(), repoUrl)
+		owner, repo, err := ghCapability.parseOwnerAndRepoFromUrl(context.TODO(), repoUrl)
 
 		assert.Equal(t, expectedOwner, owner)
 		assert.Equal(t, expectedRepo, repo)
 		assert.NoError(t, err)
 	}
 	testFail := func(t *testing.T, repoUrl string) {
-		_, _, err := fileCapability.parseOwnerAndRepoFromUrl(context.TODO(), repoUrl)
+		_, _, err := ghCapability.parseOwnerAndRepoFromUrl(context.TODO(), repoUrl)
 		assert.Error(t, err)
 	}
 

--- a/pkg/serviceprovider/github/downloadfilecapability_test.go
+++ b/pkg/serviceprovider/github/downloadfilecapability_test.go
@@ -67,7 +67,7 @@ func TestGetFileHead(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder}
+	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "HEAD", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -115,7 +115,7 @@ func TestGetFileHeadGitSuffix(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder}
+	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo.git", "myfile", "HEAD", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -162,7 +162,7 @@ func TestGetFileOnBranch(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder}
+	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "v0.1.0", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -211,7 +211,7 @@ func TestGetFileOnCommitId(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder}
+	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -249,7 +249,7 @@ func TestGetUnexistingFile(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := downloadFileCapability{client, githubClientBuilder}
+	fileCapability := downloadFileCapability{client, githubClientBuilder, "https://github.com"}
 	_, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", &api.SPIAccessToken{}, 1024)
 	if err == nil {
 		t.Error("error expected")
@@ -259,9 +259,7 @@ func TestGetUnexistingFile(t *testing.T) {
 
 func TestInvalidRepoUrl(t *testing.T) {
 	test := func(t *testing.T, repoUrl string) {
-		githubClientBuilder := githubClientBuilder{}
-
-		fileCapability := downloadFileCapability{&http.Client{}, githubClientBuilder}
+		fileCapability := downloadFileCapability{&http.Client{}, githubClientBuilder{}, "https://github.com"}
 		c, err := fileCapability.DownloadFile(context.TODO(), repoUrl, "myfile", "bla", &api.SPIAccessToken{}, 1024)
 
 		assert.Error(t, err)
@@ -273,4 +271,31 @@ func TestInvalidRepoUrl(t *testing.T) {
 	test(t, "https://github.com/org-withou-repo")
 	test(t, "https://github.com/org-withou-repo/")
 	test(t, "bla-bol")
+}
+
+func TestParseOwnerAndRepoFromUrl(t *testing.T) {
+	fileCapability := downloadFileCapability{&http.Client{}, githubClientBuilder{}, "https://github.com"}
+	testSuccess := func(t *testing.T, repoUrl, expectedOwner, expectedRepo string) {
+		owner, repo, err := fileCapability.parseOwnerAndRepoFromUrl(context.TODO(), repoUrl)
+
+		assert.Equal(t, expectedOwner, owner)
+		assert.Equal(t, expectedRepo, repo)
+		assert.NoError(t, err)
+	}
+	testFail := func(t *testing.T, repoUrl string) {
+		_, _, err := fileCapability.parseOwnerAndRepoFromUrl(context.TODO(), repoUrl)
+		assert.Error(t, err)
+	}
+
+	testSuccess(t, "https://github.com/foo-user/foo-repo", "foo-user", "foo-repo")
+	testSuccess(t, "https://github.com/foo-user/foo-repo/", "foo-user", "foo-repo")
+	testSuccess(t, "https://github.com/foo-user/foo-repo.git", "foo-user", "foo-repo")
+
+	testFail(t, "https://github.com/foo-user/foo-repo/.git")
+	testFail(t, "https://github.com/with/more/path/splits")
+	testFail(t, "https://github.com/org-withou-repo/")
+	testFail(t, "https://github.com/org-withou-repo")
+	testFail(t, "https://mygithub.com/owner/repo")
+	testFail(t, "https://my.github.com/owner/repo")
+	testFail(t, "pink-soap")
 }

--- a/pkg/serviceprovider/github/github.go
+++ b/pkg/serviceprovider/github/github.go
@@ -97,6 +97,7 @@ type Github struct {
 	ghClientBuilder        githubClientBuilder
 	downloadFileCapability downloadFileCapability
 	oauthCapability        serviceprovider.OAuthCapability
+	baseUrl                string
 }
 
 type githubOAuthCapability struct {
@@ -136,8 +137,10 @@ func newGithub(factory *serviceprovider.Factory, spConfig *config.ServiceProvide
 		downloadFileCapability: downloadFileCapability{
 			httpClient:      httpClient,
 			ghClientBuilder: ghClientBuilder,
+			githubBaseUrl:   spConfig.ServiceProviderBaseUrl,
 		},
 		oauthCapability: newGithubOAuthCapability(factory, spConfig),
+		baseUrl:         spConfig.ServiceProviderBaseUrl,
 	}
 
 	return github, nil
@@ -157,7 +160,7 @@ func newGithubOAuthCapability(factory *serviceprovider.Factory, spConfig *config
 var _ serviceprovider.ConstructorFunc = newGithub
 
 func (g *Github) GetBaseUrl() string {
-	return config.ServiceProviderTypeGitHub.DefaultBaseUrl
+	return g.baseUrl
 }
 
 func (g *Github) GetDownloadFileCapability() serviceprovider.DownloadFileCapability {

--- a/pkg/serviceprovider/github/github.go
+++ b/pkg/serviceprovider/github/github.go
@@ -95,7 +95,7 @@ type Github struct {
 	httpClient             rest.HTTPClient
 	tokenStorage           tokenstorage.TokenStorage
 	ghClientBuilder        githubClientBuilder
-	downloadFileCapability downloadFileCapability
+	downloadFileCapability serviceprovider.DownloadFileCapability
 	oauthCapability        serviceprovider.OAuthCapability
 	baseUrl                string
 }
@@ -118,6 +118,11 @@ func newGithub(factory *serviceprovider.Factory, spConfig *config.ServiceProvide
 		httpClient:   factory.HttpClient,
 	}
 
+	downloadCapability, err := NewDownloadFileCapability(httpClient, ghClientBuilder, spConfig.ServiceProviderBaseUrl)
+	if err != nil {
+		return nil, err
+	}
+
 	github := &Github{
 		Configuration: factory.Configuration,
 		tokenStorage:  factory.TokenStorage,
@@ -132,15 +137,11 @@ func newGithub(factory *serviceprovider.Factory, spConfig *config.ServiceProvide
 			MetadataCache:  &cache,
 			RepoHostParser: serviceprovider.RepoHostFromUrl,
 		},
-		httpClient:      factory.HttpClient,
-		ghClientBuilder: ghClientBuilder,
-		downloadFileCapability: downloadFileCapability{
-			httpClient:      httpClient,
-			ghClientBuilder: ghClientBuilder,
-			githubBaseUrl:   spConfig.ServiceProviderBaseUrl,
-		},
-		oauthCapability: newGithubOAuthCapability(factory, spConfig),
-		baseUrl:         spConfig.ServiceProviderBaseUrl,
+		httpClient:             factory.HttpClient,
+		ghClientBuilder:        ghClientBuilder,
+		downloadFileCapability: downloadCapability,
+		oauthCapability:        newGithubOAuthCapability(factory, spConfig),
+		baseUrl:                spConfig.ServiceProviderBaseUrl,
 	}
 
 	return github, nil

--- a/pkg/serviceprovider/github/github_test.go
+++ b/pkg/serviceprovider/github/github_test.go
@@ -111,7 +111,7 @@ func TestCheckPublicRepo(t *testing.T) {
 }
 
 func TestParseGithubRepositoryUrl(t *testing.T) {
-	gh := Github{}
+	gh := Github{baseUrl: "https://github.com"}
 
 	testOk := func(url, expectedOwner, expectedRepo string) {
 		t.Run(fmt.Sprintf("%s => %s:%s", url, expectedOwner, expectedRepo), func(t *testing.T) {
@@ -370,7 +370,8 @@ func TestNewGithub(t *testing.T) {
 		},
 		HttpClient: http.DefaultClient,
 	}
-	spConfig := &config.ServiceProviderConfiguration{}
+	baseUrl := "https://github.com"
+	spConfig := &config.ServiceProviderConfiguration{ServiceProviderBaseUrl: baseUrl}
 
 	sp, err := newGithub(factory, spConfig)
 
@@ -379,7 +380,7 @@ func TestNewGithub(t *testing.T) {
 	assert.Nil(t, sp.GetOAuthCapability())
 	assert.NotNil(t, sp.GetDownloadFileCapability())
 	assert.Equal(t, config.ServiceProviderTypeGitHub, sp.GetType())
-	assert.Equal(t, config.ServiceProviderTypeGitHub.DefaultBaseUrl, sp.GetBaseUrl())
+	assert.Equal(t, baseUrl, sp.GetBaseUrl())
 }
 
 func mockGithub(cl client.Client, returnCode int, httpErr error, lookupError error) *Github {

--- a/pkg/serviceprovider/github/githubclientbuilder.go
+++ b/pkg/serviceprovider/github/githubclientbuilder.go
@@ -52,17 +52,8 @@ func (g *githubClientBuilder) createAuthenticatedGhClient(ctx context.Context, s
 	lg.V(logs.DebugLevel).Info("Created new github client", "SPIAccessToken", spiToken)
 
 	// We need the githubBaseUrl in the githubClientBuilder struct to decide whether to create
-	// regular a GitHub client or an Enterprise client.
-	// The github library provides NewEnterpriseClient() method to create Enterprise clients.
-	// However, it takes 2 URLs as parameters: one for the API URL and one for the upload URL where files can be uploaded.
-	// These two URLs are not the same by default. baseURL should be in format http(s)://[hostname]/api/v3/ and
-	// uploadURL should be in this format http(s)://[hostname]/api/uploads/.
-	// Note that it is likely that the owner of the GitHub Enterprise instance can change the URLs. Thus, we should not assume anything.
-
-	// Our current configuration interfaces only allow for a single URL to be specified.
-	// As far as I know, we currently do not allow uploading files to GitHub, which means we might omit the uploadURL.
-	// However, we should decide formally whether to change the configuration interface to allow for two URLs or
-	// omit the uploadURL (or assume that the uploadURL will be in some format).
-
+	// regular GitHub client or an Enterprise client through the GitHub library's NewEnterpriseClient() function.
+	// However, the function takes 2 URLs as parameters: one for the API URL and one for the upload URL where files can be uploaded.
+	// As we currently do not allow uploading files to GitHub, we might omit the uploadURL.
 	return github.NewClient(oauth2.NewClient(ctx, ts)), nil
 }

--- a/pkg/serviceprovider/github/githubclientbuilder.go
+++ b/pkg/serviceprovider/github/githubclientbuilder.go
@@ -50,5 +50,19 @@ func (g *githubClientBuilder) createAuthenticatedGhClient(ctx context.Context, s
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, g.httpClient)
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tokenData.AccessToken})
 	lg.V(logs.DebugLevel).Info("Created new github client", "SPIAccessToken", spiToken)
+
+	// We need the githubBaseUrl in the githubClientBuilder struct to decide whether we need to create
+	// regular GitHub client or Enterprise client.
+	// The github library provides NewEnterpriseClient() method to create Enterprise client.
+	// However, it takes 2 URLs as parameters: one for the API URL and one for the upload URL where files can be uploaded.
+	// These two URLs are not the same by default. baseURL should be in format http(s)://[hostname]/api/v3/ and
+	// uploadURL should be in this format http(s)://[hostname]/api/uploads/.
+	// Note that it is likely that owner of the GitHub Enterprise instance can change the URLs, thus we cannot assume anything.
+
+	// Our current configuration interfaces only allow for a single URL to be specified.
+	// As far as I know, we currently do not allow uploading files to GitHub which means we might omit the uploadURL.
+	// However, we should decide formally whether we should change the configuration interface to allow for two URLs, or
+	// we should just omit the uploadURL.
+
 	return github.NewClient(oauth2.NewClient(ctx, ts)), nil
 }

--- a/pkg/serviceprovider/github/githubclientbuilder.go
+++ b/pkg/serviceprovider/github/githubclientbuilder.go
@@ -51,18 +51,18 @@ func (g *githubClientBuilder) createAuthenticatedGhClient(ctx context.Context, s
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: tokenData.AccessToken})
 	lg.V(logs.DebugLevel).Info("Created new github client", "SPIAccessToken", spiToken)
 
-	// We need the githubBaseUrl in the githubClientBuilder struct to decide whether we need to create
-	// regular GitHub client or Enterprise client.
-	// The github library provides NewEnterpriseClient() method to create Enterprise client.
+	// We need the githubBaseUrl in the githubClientBuilder struct to decide whether to create
+	// regular a GitHub client or an Enterprise client.
+	// The github library provides NewEnterpriseClient() method to create Enterprise clients.
 	// However, it takes 2 URLs as parameters: one for the API URL and one for the upload URL where files can be uploaded.
 	// These two URLs are not the same by default. baseURL should be in format http(s)://[hostname]/api/v3/ and
 	// uploadURL should be in this format http(s)://[hostname]/api/uploads/.
-	// Note that it is likely that owner of the GitHub Enterprise instance can change the URLs, thus we cannot assume anything.
+	// Note that it is likely that the owner of the GitHub Enterprise instance can change the URLs. Thus, we should not assume anything.
 
 	// Our current configuration interfaces only allow for a single URL to be specified.
-	// As far as I know, we currently do not allow uploading files to GitHub which means we might omit the uploadURL.
-	// However, we should decide formally whether we should change the configuration interface to allow for two URLs, or
-	// we should just omit the uploadURL.
+	// As far as I know, we currently do not allow uploading files to GitHub, which means we might omit the uploadURL.
+	// However, we should decide formally whether to change the configuration interface to allow for two URLs or
+	// omit the uploadURL (or assume that the uploadURL will be in some format).
 
 	return github.NewClient(oauth2.NewClient(ctx, ts)), nil
 }


### PR DESCRIPTION
### What does this PR do?
When a custom GitHub URL is set in the shared configuration, this PR ensures that:
1. SPIAccessTokenBinding with repoUrl based on that custom URL is linked to a correct SPIAccessToken (token should have GitHub type and custom host. e.g., mygithub.com). 
2. SPIFileContentRequest with repoUrl based on that custom URL correctly parses the owner and repository from that repoUrl.

NOTE: This PR is not enough to make SPI work with GitHub instances with custom URLs (AKA GitHub Enterprise Server).
The reason is we still use the default GitHub client in code (for calling GitHub API), which uses https://github.com URL. I wrote down a comment which explains this situation and what we need to do, I will copy it here:

We need the githubBaseUrl in the githubClientBuilder struct to decide whether to create a regular GitHub client or an Enterprise client.
The github library provides NewEnterpriseClient() method to create Enterprise clients.
However, it takes 2 URLs as parameters: one for the API URL and one for the upload URL where files can be uploaded.
These two URLs are not the same by default. baseURL should be in format http(s)://[hostname]/api/v3/ and
uploadURL should be in this format http(s)://[hostname]/api/uploads/.
Note that it is likely that the owner of the GitHub Enterprise instance can change the URLs. Thus, we should not assume anything.
Our current configuration interfaces only allow for a single URL to be specified.
As far as I know, we currently do not allow uploading files to GitHub, which means we might omit the uploadURL.
However, we should decide formally whether to change the service provider configuration interface to allow for two URLs or omit the uploadURL (or assume that the uploadURL will be in some format).


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->
![image](https://user-images.githubusercontent.com/73115616/235461851-98fb68fb-9850-4346-8964-a19adb5fd421.png)
![image](https://user-images.githubusercontent.com/73115616/235461742-7ebc7fea-14d4-4b32-970e-d96cd85b630f.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
Part of https://issues.redhat.com/browse/SVPI-453

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
 1. Edit the shared service provider configuration (restart deployments afterward) so that GitHub has a custom URL e.g., to:
 ```
serviceProviders:
- type: GitHub
  clientId: "123"
  clientSecret: "42"
  baseUrl: "https://mygithub.com"
```
2. Create binding with repoUrl based on the custom URL:
```bash
cat <<EOF | kubectl apply -f -
apiVersion: appstudio.redhat.com/v1beta1
kind: SPIAccessTokenBinding
metadata:
  name: test-binding
  namespace: default
spec:
  permissions:
    required:
      - type: rw
        area: repository
  repoUrl: https://mygithub.com/testingorganization/test
  secret:
    name: test-secret
EOF
```
 3. Check the linked SPIAccessToken; it should have the type GitHub, the host should be mygithub.com, and it should have an oauthURL. This checks the first feature of the PR.
 
 1. On regular GitHub (https://github.com/settings/tokens), create a personal access token with `repo` scope and save it.
 2. Create SPIFileContentRequest but change the path to reference your private repository on github.com. The URL mygithub.com is intentional here; the reason is that right now, we only parse the owner and repository name out of the repoUrl but always use a client with github.com URL: 
 ```bash
cat <<EOF | kubectl apply -f -
apiVersion: appstudio.redhat.com/v1beta1
kind: SPIFileContentRequest
metadata:
  name: test-file-content-request
  namespace: default
spec:
  repoUrl: https://mygithub.com/xbaran4/testing
  filePath: devfile.yaml
EOF
```
3. Check the SPIAccessTokenBinding created for the SPIFileContentRequest; it should have the oauthUrl and uploadUrl.
4. Upload your PAT token for the SPIAccessTokenBinding's SPIAccessToken.
5. If you uploaded a valid token and the repoUrl in SPIFileContentRequest had a valid path to your repo, the SPIFileContentRequest should be in phase: Delivered

```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
