### PR TITLE
Store secrets in Vault by k8s UID

### DIFF
--- a/pkg/spi-shared/secretstorage/vaultstorage/vault_login_test.go
+++ b/pkg/spi-shared/secretstorage/vaultstorage/vault_login_test.go
@@ -55,6 +55,7 @@ func TestVaultLogin_Renewal(t *testing.T) {
 	assert.NotEqual(t, origToken, ts.client.Token())
 
 	secretId := secretstorage.SecretID{
+		Uid:       "test-uid",
 		Name:      "test",
 		Namespace: "test",
 	}

--- a/pkg/spi-shared/secretstorage/vaultstorage/vault_test.go
+++ b/pkg/spi-shared/secretstorage/vaultstorage/vault_test.go
@@ -397,14 +397,14 @@ func TestHandlingOfLegacyDataInGet(t *testing.T) {
 
 	// save legacy data to the cluster
 	cl := cluster.Cores[0].Client
-	_, err := cl.Logical().Write("spi/data/default/token", map[string]any{
+	_, err := cl.Logical().Write("spi/data/test-uid", map[string]any{
 		"data": map[string]any{
 			"access_token": "kachny",
 		},
 	})
 	assert.NoError(t, err)
 
-	data, err := storage.Get(context.TODO(), secretstorage.SecretID{Name: "token", Namespace: "default"})
+	data, err := storage.Get(context.TODO(), secretstorage.SecretID{Uid: "test-uid", Name: "token", Namespace: "default"})
 	assert.NoError(t, err)
 
 	expectedToken := api.Token{
@@ -416,7 +416,7 @@ func TestHandlingOfLegacyDataInGet(t *testing.T) {
 	assert.Equal(t, expectedToken, actualToken)
 
 	// also, let's check that the data in the cluster has been upgraded to the new format
-	secret, err := cl.Logical().Read("spi/data/default/token")
+	secret, err := cl.Logical().Read("spi/data/test-uid")
 	assert.NoError(t, err)
 	dataField := secret.Data["data"]
 	dataMap := dataField.(map[string]any)


### PR DESCRIPTION
### What does this PR do?
Stores secrets by k8s object UID in Vault storage.

This PR is not adding data migration. That means, that if you have some secrets stored in current version, they will switch to `AwaitingTokenData` after this update. I believe this is not needed as we don't have any long-term environment running on vault.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-478

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->


```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-597
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-597
```

1. Deploy and upload some token
2. Check that it is stored by SPIAccessToken UID in the Vault
