### PR TITLE
ensuring gitlab spiaccesscheck works by proper repoUrl matching

### DIFF
--- a/pkg/serviceprovider/gitlab/downloadfilecapability_test.go
+++ b/pkg/serviceprovider/gitlab/downloadfilecapability_test.go
@@ -69,7 +69,10 @@ func TestGetFileHead(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com")
+	repoUrlMatcher, err := newRepoUrlMatcher("https://fake.github.com")
+	assert.NoError(t, err)
+
+	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com", repoUrlMatcher)
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo", "myfile", "", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -116,7 +119,10 @@ func TestGetFileHeadGitSuffix(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com")
+	repoUrlMatcher, err := newRepoUrlMatcher("https://fake.github.com")
+	assert.NoError(t, err)
+
+	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com", repoUrlMatcher)
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo.git", "myfile", "", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -163,7 +169,10 @@ func TestGetFileOnBranch(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com")
+	repoUrlMatcher, err := newRepoUrlMatcher("https://fake.github.com")
+	assert.NoError(t, err)
+
+	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com", repoUrlMatcher)
 	content, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo.git", "myfile", "v0.1.0", &api.SPIAccessToken{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -201,7 +210,10 @@ func TestGetUnexistingFile(t *testing.T) {
 		tokenStorage: ts,
 	}
 
-	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com")
+	repoUrlMatcher, matcherErr := newRepoUrlMatcher("https://fake.github.com")
+	assert.NoError(t, matcherErr)
+
+	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com", repoUrlMatcher)
 	_, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", &api.SPIAccessToken{}, 1024)
 	if err == nil {
 		t.Error("error expected")

--- a/pkg/serviceprovider/gitlab/gitlab.go
+++ b/pkg/serviceprovider/gitlab/gitlab.go
@@ -97,6 +97,11 @@ func newGitlab(factory *serviceprovider.Factory, spConfig *config.ServiceProvide
 		}
 	}
 
+	repoUrlMatcher, err := newRepoUrlMatcher(spConfig.ServiceProviderBaseUrl)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Gitlab{
 		Configuration: factory.Configuration,
 		lookup: serviceprovider.GenericLookup{
@@ -116,7 +121,7 @@ func newGitlab(factory *serviceprovider.Factory, spConfig *config.ServiceProvide
 			oauthServiceBaseUrl: factory.Configuration.BaseUrl,
 		},
 		baseUrl:                spConfig.ServiceProviderBaseUrl,
-		downloadFileCapability: NewDownloadFileCapability(factory.HttpClient, glClientBuilder, spConfig.ServiceProviderBaseUrl),
+		downloadFileCapability: NewDownloadFileCapability(factory.HttpClient, glClientBuilder, spConfig.ServiceProviderBaseUrl, repoUrlMatcher),
 		oauthCapability:        oauthCapability,
 	}, nil
 }

--- a/pkg/serviceprovider/gitlab/gitlab.go
+++ b/pkg/serviceprovider/gitlab/gitlab.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/config"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/httptransport"
@@ -46,9 +45,6 @@ var probeNotImplementedError = errors.New("gitLab probe not implemented")
 var publicRepoMetricConfig = serviceprovider.CommonRequestMetricsConfig(config.ServiceProviderTypeGitLab, "fetch_public_repo")
 var fetchRepositoryMetricConfig = serviceprovider.CommonRequestMetricsConfig(config.ServiceProviderTypeGitLab, "fetch_single_repo")
 
-// Temp
-var notGitlabUrlError = errors.New("not a gitlab repository url")
-
 var _ serviceprovider.ServiceProvider = (*Gitlab)(nil)
 
 type Gitlab struct {
@@ -62,6 +58,7 @@ type Gitlab struct {
 	downloadFileCapability downloadFileCapability
 	refreshTokenCapability serviceprovider.RefreshTokenCapability
 	oauthCapability        serviceprovider.OAuthCapability
+	repoUrlMatcher         gitlabRepoUrlMatcher
 }
 
 var _ serviceprovider.ConstructorFunc = newGitlab
@@ -123,6 +120,7 @@ func newGitlab(factory *serviceprovider.Factory, spConfig *config.ServiceProvide
 		baseUrl:                spConfig.ServiceProviderBaseUrl,
 		downloadFileCapability: NewDownloadFileCapability(factory.HttpClient, glClientBuilder, spConfig.ServiceProviderBaseUrl, repoUrlMatcher),
 		oauthCapability:        oauthCapability,
+		repoUrlMatcher:         repoUrlMatcher,
 	}, nil
 }
 
@@ -199,7 +197,7 @@ func (g Gitlab) CheckRepositoryAccess(ctx context.Context, cl client.Client, acc
 		Accessibility:   api.SPIAccessCheckAccessibilityUnknown,
 	}
 
-	repo, err := g.parseGitlabRepoUrl(accessCheck.Spec.RepoUrl)
+	owner, project, err := g.repoUrlMatcher.parseOwnerAndProjectFromUrl(ctx, accessCheck.Spec.RepoUrl)
 	if err != nil {
 		status.ErrorReason = api.SPIAccessCheckErrorBadURL
 		status.ErrorMessage = err.Error()
@@ -235,13 +233,13 @@ func (g Gitlab) CheckRepositoryAccess(ctx context.Context, cl client.Client, acc
 	}
 	token := &tokens[0]
 
-	if err := g.checkPrivateRepoAccess(ctx, token, repo, status); err != nil {
+	if err := g.checkPrivateRepoAccess(ctx, token, owner+"/"+project, status); err != nil {
 		return nil, err
 	}
 	return status, nil
 }
 
-func (g *Gitlab) checkPrivateRepoAccess(ctx context.Context, token *api.SPIAccessToken, repo string, status *api.SPIAccessCheckStatus) error {
+func (g *Gitlab) checkPrivateRepoAccess(ctx context.Context, token *api.SPIAccessToken, projectIdentifier string, status *api.SPIAccessCheckStatus) error {
 	glClient, err := g.glClientBuilder.createGitlabAuthClient(ctx, token, g.baseUrl)
 	if err != nil {
 		status.ErrorReason = api.SPIAccessCheckErrorUnknownError
@@ -249,7 +247,7 @@ func (g *Gitlab) checkPrivateRepoAccess(ctx context.Context, token *api.SPIAcces
 		return err
 	}
 
-	project, response, err := glClient.Projects.GetProject(repo, nil, gitlab.WithContext(ctx))
+	project, response, err := glClient.Projects.GetProject(projectIdentifier, nil, gitlab.WithContext(ctx))
 	if err != nil {
 		status.ErrorReason = api.SPIAccessCheckErrorRepoNotFound
 		status.ErrorMessage = err.Error()
@@ -298,14 +296,6 @@ func (g *Gitlab) isPublicRepo(ctx context.Context, accessCheck *api.SPIAccessChe
 		lg.Info("unexpected return code for repo", "accessCheck", accessCheck, "code", resp.StatusCode)
 	}
 	return false, nil
-}
-
-// Temp
-func (g *Gitlab) parseGitlabRepoUrl(repoUrl string) (repoPath string, err error) {
-	if !strings.HasPrefix(repoUrl, g.GetBaseUrl()) {
-		return "", fmt.Errorf("%w: '%s'", notGitlabUrlError, repoUrl)
-	}
-	return strings.TrimPrefix(repoUrl, g.GetBaseUrl()), nil
 }
 
 func (g Gitlab) MapToken(_ context.Context, _ *api.SPIAccessTokenBinding, token *api.SPIAccessToken, tokenData *api.Token) (serviceprovider.AccessTokenMapper, error) {

--- a/pkg/serviceprovider/gitlab/gitlab_test.go
+++ b/pkg/serviceprovider/gitlab/gitlab_test.go
@@ -287,6 +287,7 @@ func mockGitlab(cl client.Client, returnCode int, body string, responseError err
 		}),
 	}
 
+	matcher, _ := newRepoUrlMatcher(config.ServiceProviderTypeGitLab.DefaultBaseUrl)
 	return &Gitlab{
 		Configuration: &opconfig.OperatorConfiguration{SharedConfiguration: config.SharedConfiguration{BaseUrl: "https://test.url"}},
 		httpClient:    httpClientMock,
@@ -307,6 +308,7 @@ func mockGitlab(cl client.Client, returnCode int, body string, responseError err
 			httpClient:   httpClientMock,
 			tokenStorage: tokenStorageMock,
 		},
+		repoUrlMatcher: matcher,
 	}
 }
 

--- a/pkg/serviceprovider/gitlab/repourlmatcher.go
+++ b/pkg/serviceprovider/gitlab/repourlmatcher.go
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/logs"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type gitlabRepoUrlMatcher struct {
+	regexp  *regexp.Regexp
+	baseUrl string
+}
+
+func newRepoUrlMatcher(baseUrl string) (gitlabRepoUrlMatcher, error) {
+	regex, err := regexp.Compile(`(?Um)^` + regexp.QuoteMeta(baseUrl) + `/(?P<owner>[^/]+)/(?P<project>[^/]+)(/|(.git)?)$`)
+	if err != nil {
+		return gitlabRepoUrlMatcher{}, fmt.Errorf("compliling repoUrl matching regexp for GitLab baseUrl %s failed with error: %w", baseUrl, err)
+	}
+	return gitlabRepoUrlMatcher{
+		regexp:  regex,
+		baseUrl: baseUrl,
+	}, nil
+}
+
+func (r gitlabRepoUrlMatcher) parseOwnerAndProjectFromUrl(ctx context.Context, repoUrl string) (owner, repo string, err error) {
+	urlRegexpNames := r.regexp.SubexpNames()
+	matches := r.regexp.FindAllStringSubmatch(repoUrl, -1)
+	if len(matches) == 0 {
+		return "", "", fmt.Errorf("failed to match GitLab repository with baseUrl %s: %w", r.baseUrl, unexpectedRepoUrlError)
+	}
+
+	matchesMap := map[string]string{}
+	for i, n := range matches[0] {
+		matchesMap[urlRegexpNames[i]] = n
+	}
+	log.FromContext(ctx).V(logs.DebugLevel).Info("parsed values from GitLab repoUrl",
+		"GitLab baseUrl", r.baseUrl, "owner", matchesMap["owner"], "repo", matchesMap["project"])
+	return matchesMap["owner"], matchesMap["project"], nil
+}

--- a/pkg/serviceprovider/gitlab/repourlmatcher_test.go
+++ b/pkg/serviceprovider/gitlab/repourlmatcher_test.go
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlab
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOwnerAndProjectFromUrl(t *testing.T) {
+	matcher, err := newRepoUrlMatcher("https://personal.gitlab.com")
+	assert.NoError(t, err)
+
+	testSuccess := func(t *testing.T, repoUrl, expectedOwner, expectedRepo string) {
+		owner, repo, err := matcher.parseOwnerAndProjectFromUrl(context.TODO(), repoUrl)
+
+		assert.Equal(t, expectedOwner, owner)
+		assert.Equal(t, expectedRepo, repo)
+		assert.NoError(t, err)
+	}
+	testFail := func(t *testing.T, repoUrl string) {
+		_, _, err := matcher.parseOwnerAndProjectFromUrl(context.TODO(), repoUrl)
+		assert.Error(t, err)
+	}
+
+	testSuccess(t, "https://personal.gitlab.com/foo-user/foo-project", "foo-user", "foo-project")
+	testSuccess(t, "https://personal.gitlab.com/foo-user/foo-project/", "foo-user", "foo-project")
+	testSuccess(t, "https://personal.gitlab.com/foo-user/foo-project.git", "foo-user", "foo-project")
+
+	testFail(t, "https://personal.gitlab.com/foo-user/foo-repo/.git/")
+	testFail(t, "https://personal.gitlab.com/foo-user/foo-repo/.git")
+	testFail(t, "https://personal.gitlab.com/with/more/path/splits")
+	testFail(t, "https://personal.gitlab.com/owner/")
+	testFail(t, "https://personal.gitlab.com")
+	testFail(t, "https://gitlab.com/owner/repo")
+	testFail(t, "https://github.com/owner/repo")
+	testFail(t, "duck")
+
+}


### PR DESCRIPTION
### What does this PR do?
Fixes SVPI-456 bug where SPIAccessCheck would not work because of wrong repoUrl parsing. The PR introduces repoUrlMatcher struct. It allows us to "precompile" the regexp and have it available from both gitlab and downloadfilecapability structs to parse the repoUrl and obtain owner and project names.

You may notice that the parsing looks quite like my previous PR https://github.com/redhat-appstudio/service-provider-integration-operator/pull/590. Since parsing of GitLab and GitHub repoUrls is very similar indeed, I had the idea of some sort of abstraction and extracting the code. However, in the end, I decided not to, as every abstraction makes the code harder to read, and I do not think it will be very useful in the future because new service providers' repoUrls will probably need to be parsed in different ways (as is the case with Quay already) 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
fixes https://issues.redhat.com/browse/SVPI-456

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
1. create and save your GitLab personal access token (https://gitlab.com/-/profile/personal_access_tokens)

```shell
GITLAB_PAT=xxx # your token
```

2. upload the token
```shell
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Secret
metadata:
  name: test-secret
  labels:
    spi.appstudio.redhat.com/upload-secret: token
type: Opaque
stringData:
  spiTokenName: my-spi-access-token-gitlab
  providerUrl: https://gitlab.com/
  tokenData: ${GITLAB_PAT}
EOF
```

3. create access check for your repository on GitLab and check the result; it should be private and accessible 
```shell

cat <<EOF | kubectl apply -f -
apiVersion: appstudio.redhat.com/v1beta1
kind: SPIAccessCheck
metadata:
  name: spiaccesscheck-gitlab-private-with-token
spec:
  repoUrl: https://gitlab.com/xbaran4/test # replace with your private repo
EOF
```

4. create file request for your repository on GitLab and check the result; it should be delivered
```shell
cat <<EOF | kubectl apply -f -
apiVersion: appstudio.redhat.com/v1beta1
kind: SPIFileContentRequest
metadata:
  name: test-file-content-request
  namespace: default
spec:
  repoUrl: https://gitlab.com/xbaran4/test # replace with your private repo
  filePath: README.md # replace with a file in that repo
EOF
```



```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
