### PR TITLE
An attempt at bringing more discipline and per-stage error reporting to the reconciliation.

### DIFF
--- a/api/v1beta1/remotesecret_types.go
+++ b/api/v1beta1/remotesecret_types.go
@@ -75,13 +75,14 @@ type RemoteSecretConditionType string
 const (
 	RemoteSecretConditionTypeDeployed     RemoteSecretConditionType = "Deployed"
 	RemoteSecretConditionTypeDataObtained RemoteSecretConditionType = "DataObtained"
-	RemoteSecretConditionTypeError        RemoteSecretConditionType = "Error"
+	RemoteSecretConditionTypeSpecValid    RemoteSecretConditionType = "SpecValid"
 
 	RemoteSecretReasonAwaitingTokenData RemoteSecretReason = "AwaitingData"
+	RemoteSecretReasonDataFound         RemoteSecretReason = "DataFound"
 	RemoteSecretReasonInjected          RemoteSecretReason = "Injected"
+	RemoteSecretReasonPartiallyInjected RemoteSecretReason = "PartiallyInjected"
 	RemoteSecretReasonError             RemoteSecretReason = "Error"
-	RemoteSecretReasonCreated           RemoteSecretReason = "Created"
-	RemoteSecretReasonUnsupported       RemoteSecretReason = "Unsupported"
+	RemoteSecretReasonValid             RemoteSecretReason = "Valid"
 )
 
 //+kubebuilder:object:root=true


### PR DESCRIPTION
### What does this PR do?
We chose to report the state of a remote secret using conditions that describe what is happening with it in more detail than just phase, reason and error.

This PR tries to bring more order into the reconciliation by splitting it into distinct stages, each of which perists its own condition in the status.

### What issues does this PR fix or reference?
none

### How to test this PR?
Apply the `samples/remote-secret.yaml` sample. Notice there should be two conditions in its status: one saying that the spec is valid (result of the validation stage) and another saying that the data has not yet been obtained.

```yaml
status:
    conditions:
    - lastTransitionTime: "2023-05-16T10:40:32Z"
      message: ""
      reason: Valid
      status: "True"
      type: SpecValid
    - lastTransitionTime: "2023-05-16T10:40:32Z"
      message: The data of the remote secret not found in storage. Please provide
        it.
      reason: AwaitingData
      status: "False"
      type: DataObtained
```

After you provide data to the remote secret, e.g. by applying the `samples/remote-secret-secret.yaml`, you should see 3 conditions: the spec is valid, the data has been obtained and the secrets deployed.

```yaml
status:
    conditions:
    - lastTransitionTime: "2023-05-16T10:40:32Z"
      message: ""
      reason: Valid
      status: "True"
      type: SpecValid
    - lastTransitionTime: "2023-05-16T10:41:02Z"
      message: ""
      reason: DataFound
      status: "True"
      type: DataObtained
    - lastTransitionTime: "2023-05-16T10:41:02Z"
      message: ""
      reason: Injected
      status: "True"
      type: Deployed
    targets:
    - namespace:
        namespace: test-target-namespace
        secretName: secret-from-remote-lr6bg
        serviceAccountNames:
        - sa-from-remote-h5925
```


```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-603
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-603
```
