### PR TITLE
Fix NPE while processing targets to delete

### DIFF
--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -449,7 +449,7 @@ func (r *RemoteSecretReconciler) clientForTarget(targetSpec *api.RemoteSecretTar
 	} else {
 		return r.Client
 	}
-	
+
 	if apiUrl == "" {
 		return r.Client
 	}

--- a/controllers/remotesecret_controller.go
+++ b/controllers/remotesecret_controller.go
@@ -427,7 +427,7 @@ func (r *RemoteSecretReconciler) deleteFromNamespace(ctx context.Context, remote
 func (r *RemoteSecretReconciler) newDependentsHandler(remoteSecret *api.RemoteSecret, targetSpec *api.RemoteSecretTarget, targetStatus *api.TargetStatus) bindings.DependentsHandler[*api.RemoteSecret] {
 	return bindings.DependentsHandler[*api.RemoteSecret]{
 		Target: &namespacetarget.NamespaceTarget{
-			Client:       r.clientForTarget(targetSpec),
+			Client:       r.clientForTarget(targetSpec, targetStatus),
 			TargetKey:    client.ObjectKeyFromObject(remoteSecret),
 			SecretSpec:   &remoteSecret.Spec.Secret,
 			TargetSpec:   targetSpec,
@@ -440,8 +440,17 @@ func (r *RemoteSecretReconciler) newDependentsHandler(remoteSecret *api.RemoteSe
 	}
 }
 
-func (r *RemoteSecretReconciler) clientForTarget(targetSpec *api.RemoteSecretTarget) client.Client {
-	if targetSpec.ApiUrl == "" {
+func (r *RemoteSecretReconciler) clientForTarget(targetSpec *api.RemoteSecretTarget, targetStatus *api.TargetStatus) client.Client {
+	var apiUrl string
+	if targetStatus != nil {
+		apiUrl = targetStatus.ApiUrl
+	} else if targetSpec != nil {
+		apiUrl = targetSpec.ApiUrl
+	} else {
+		return r.Client
+	}
+	
+	if apiUrl == "" {
 		return r.Client
 	}
 


### PR DESCRIPTION
### What does this PR do?
Fix the NPE by taking into account the fact that the API URL might only be specified in the status of the target, not just in the spec.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-498

### How to test this PR?
Create a remote secret with data and some targets. Then remove a target from the remote secret. The operator should no longer crash.