### PR TITLE
Register remote CRDs into integration tests suite and try to use them

### DIFF
--- a/integration_tests/integrationtest.go
+++ b/integration_tests/integrationtest.go
@@ -17,11 +17,12 @@ package integrationtests
 import (
 	"context"
 	"fmt"
-	"github.com/redhat-appstudio/application-api/api/v1alpha1"
-	rapi "github.com/redhat-appstudio/remote-secret/api/v1beta1"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/redhat-appstudio/application-api/api/v1alpha1"
+	rapi "github.com/redhat-appstudio/remote-secret/api/v1beta1"
 
 	rconfig "github.com/redhat-appstudio/remote-secret/pkg/config"
 

--- a/integration_tests/snapshotenvironmentbinding_controller_test.go
+++ b/integration_tests/snapshotenvironmentbinding_controller_test.go
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2021 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integrationtests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/application-api/api/v1alpha1"
+	rapi "github.com/redhat-appstudio/remote-secret/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("SnapshotEnvironmentBinding", func() {
+
+	Describe("Creates new target for RemoteSecret", func() {
+
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				RemoteSecrets: []*rapi.RemoteSecret{{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "create-target-remotesecret-",
+						Namespace:    "default",
+						Labels:       map[string]string{"appstudio.application": "test-app", "appstudio.environment": "test-env"},
+					},
+					Spec: rapi.RemoteSecretSpec{
+						Secret: rapi.LinkableSecretSpec{
+							Name: "test-remote-secret",
+							Type: "Opaque",
+						},
+					},
+				}},
+				Environments: []*v1alpha1.Environment{StandardEnvironment("test-env")},
+				SnapshotEnvBindings: []*v1alpha1.SnapshotEnvironmentBinding{{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "create-target-snapshotbinding-",
+						Namespace:    "default",
+						Labels:       map[string]string{"appstudio.application": "test-app", "appstudio.environment": "test-env"},
+					},
+					Spec: v1alpha1.SnapshotEnvironmentBindingSpec{
+						Application: "test-app",
+						Environment: "test-env",
+						Components:  []v1alpha1.BindingComponent{},
+					},
+				}},
+			},
+			Behavior: ITestBehavior{},
+		}
+		BeforeEach(func() {
+			testSetup.BeforeEach(nil)
+		})
+
+		var _ = AfterEach(func() {
+			testSetup.AfterEach()
+		})
+
+		It("have the target set", func() {
+			testSetup.ReconcileWithCluster(func(g Gomega) {
+				g.Expect(testSetup.InCluster.RemoteSecrets[0].Spec.Targets[0].Namespace == "default").To(BeTrue())
+			})
+		})
+
+	})
+
+})

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -15,13 +15,14 @@
 package integrationtests
 
 import (
+	"io"
+
 	"github.com/onsi/ginkgo"
 	"github.com/redhat-appstudio/application-api/api/v1alpha1"
 	rapi "github.com/redhat-appstudio/remote-secret/api/v1beta1"
 	"github.com/redhat-appstudio/remote-secret/pkg/kubernetesclient"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"golang.org/x/oauth2"
-	"io"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"sigs.k8s.io/controller-runtime/pkg/cluster"


### PR DESCRIPTION
### What does this PR do?
Registers remote CRDs for integration tests:
 - RemoteSecret
 - Environment
 - SnapshotEnvironmentBidning
 
 Added happy path test for target setting controller.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-523

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
