### PR TITLE
Align label names with current ADR

### DIFF
--- a/controllers/snapshotenvironmentbinding_controller.go
+++ b/controllers/snapshotenvironmentbinding_controller.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	ApplicationLabelName                   = "appstudio.application"
-	EnvironmentLabelName                   = "appstudio.environment"
-	ComponentLabelName                     = "appstudio.component"
+	ApplicationLabelName                   = "appstudio.openshift.io/application"
+	EnvironmentLabelName                   = "appstudio.openshift.io/environment"
+	ComponentLabelName                     = "appstudio.openshift.io/component"
 	linkedRemoteSecretsTargetFinalizerName = "spi.appstudio.redhat.com/remote-secrets" //#nosec G101 -- false positive, just label name
 )
 

--- a/controllers/snapshotenvironmentbinding_controller.go
+++ b/controllers/snapshotenvironmentbinding_controller.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	ApplicationLabelName                   = "appstudio.openshift.io/application"
-	EnvironmentLabelName                   = "appstudio.openshift.io/environment"
-	ComponentLabelName                     = "appstudio.openshift.io/component"
+	ApplicationLabelName                   = "appstudio.redhat.com/application"
+	EnvironmentLabelName                   = "appstudio.redhat.com/environment"
+	ComponentLabelName                     = "appstudio.redhat.com/component"
 	linkedRemoteSecretsTargetFinalizerName = "spi.appstudio.redhat.com/remote-secrets" //#nosec G101 -- false positive, just label name
 )
 

--- a/integration_tests/snapshotenvironmentbinding_controller_test.go
+++ b/integration_tests/snapshotenvironmentbinding_controller_test.go
@@ -32,7 +32,7 @@ var _ = Describe("SnapshotEnvironmentBinding", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "create-target-remotesecret-",
 						Namespace:    "default",
-						Labels:       map[string]string{"appstudio.openshift.io/application": "test-app", "appstudio.openshift.io/environment": "test-env"},
+						Labels:       map[string]string{"appstudio.redhat.com/application": "test-app", "appstudio.redhat.com/environment": "test-env"},
 					},
 					Spec: rapi.RemoteSecretSpec{
 						Secret: rapi.LinkableSecretSpec{
@@ -46,7 +46,7 @@ var _ = Describe("SnapshotEnvironmentBinding", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "create-target-snapshotbinding-",
 						Namespace:    "default",
-						Labels:       map[string]string{"appstudio.openshift.io/application": "test-app", "appstudio.openshift.io/environment": "test-env"},
+						Labels:       map[string]string{"appstudio.redhat.com/application": "test-app", "appstudio.redhat.com/environment": "test-env"},
 					},
 					Spec: v1alpha1.SnapshotEnvironmentBindingSpec{
 						Application: "test-app",

--- a/integration_tests/snapshotenvironmentbinding_controller_test.go
+++ b/integration_tests/snapshotenvironmentbinding_controller_test.go
@@ -32,7 +32,7 @@ var _ = Describe("SnapshotEnvironmentBinding", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "create-target-remotesecret-",
 						Namespace:    "default",
-						Labels:       map[string]string{"appstudio.application": "test-app", "appstudio.environment": "test-env"},
+						Labels:       map[string]string{"appstudio.openshift.io/application": "test-app", "appstudio.openshift.io/environment": "test-env"},
 					},
 					Spec: rapi.RemoteSecretSpec{
 						Secret: rapi.LinkableSecretSpec{
@@ -46,7 +46,7 @@ var _ = Describe("SnapshotEnvironmentBinding", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "create-target-snapshotbinding-",
 						Namespace:    "default",
-						Labels:       map[string]string{"appstudio.application": "test-app", "appstudio.environment": "test-env"},
+						Labels:       map[string]string{"appstudio.openshift.io/application": "test-app", "appstudio.openshift.io/environment": "test-env"},
 					},
 					Spec: v1alpha1.SnapshotEnvironmentBindingSpec{
 						Application: "test-app",


### PR DESCRIPTION
### What does this PR do?
Application/component/environment label names must conform the current ADR 
https://github.com/redhat-appstudio/book/blob/main/ADR/0022-secret-mgmt-for-user-workloads.md


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-543

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
