### PR TITLE
Add support for BYOC environments targets

### DIFF
--- a/integration_tests/integrationtest.go
+++ b/integration_tests/integrationtest.go
@@ -266,7 +266,7 @@ func StandardTestBinding(namePrefix string) *api.SPIAccessTokenBinding {
 	}
 }
 
-func StandardEnvironment(name string) *v1alpha1.Environment {
+func StandardLocalEnvironment(name string) *v1alpha1.Environment {
 	return &v1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -276,6 +276,28 @@ func StandardEnvironment(name string) *v1alpha1.Environment {
 			Type: "Non-POC",
 			Configuration: v1alpha1.EnvironmentConfiguration{
 				Env: []v1alpha1.EnvVarPair{},
+			},
+		},
+	}
+}
+
+func StandardRemoteEnvironment(name string) *v1alpha1.Environment {
+	return &v1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: v1alpha1.EnvironmentSpec{
+			Tags: []string{"managed"},
+			Configuration: v1alpha1.EnvironmentConfiguration{
+				Env: []v1alpha1.EnvVarPair{},
+			},
+			UnstableConfigurationFields: &v1alpha1.UnstableEnvironmentConfiguration{
+				KubernetesClusterCredentials: v1alpha1.KubernetesClusterCredentials{
+					APIURL:                   "https://api.example.com",
+					ClusterCredentialsSecret: "cluster-credentials-secret",
+					TargetNamespace:          "target-ns",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?
Add support for BYOC environments targets injection into RemoteSecret

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-522

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->
 
 - Deploy RHTAP on RHPDS by usual procedure;
 - Create managed environment:
 ```
 apiVersion: appstudio.redhat.com/v1alpha1
kind: Environment
metadata:
  name: development
  namespace: default
spec:
  deploymentStrategy: AppStudioAutomated
  displayName: rhpds
  tags:
    - managed
  unstableConfigurationFields:
    clusterType: OpenShift
    kubernetesCredentials:
      allowInsecureSkipTLSVerify: true
      apiURL: 'https://api.cluster-vj5m7.vj5m7.sandbox687.opentlc.com:6443'
      clusterCredentialsSecret: env-cluster-credentials-rnnhh
      namespaces:
        - default
      targetNamespace: default
````

- Create RS:
```
apiVersion: appstudio.redhat.com/v1beta1
kind: RemoteSecret
metadata:
  name: test-remote-secret2
  namespace: default
  labels:
    appstudio.redhat.com/application: rs-sample
    appstudio.redhat.com/environment: development
spec:
  secret:
    name: demo-secret-from-remote
    type: Opaque
```
      
- Create SEB:
```
apiVersion: appstudio.redhat.com/v1alpha1
kind: SnapshotEnvironmentBinding
metadata:
  labels:
    appstudio.application: rs-sample
    appstudio.environment: development
  name: seb-development
  namespace: default
spec:
  application: rs-sample
  components:
  - configuration:
      replicas: 1
    name: devfile-sample-go-basic-fwzb
  environment: development
  snapshot: so-sample-zqpl
```      



Remote secret must have  the target injected:

![image](https://github.com/redhat-appstudio/service-provider-integration-operator/assets/1651062/964be436-539f-4c6d-b328-08dc111042f3)


```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
