### PR TITLE
Fix targets detection and iteration

### DIFF
--- a/controllers/snapshotenvironmentbinding_controller.go
+++ b/controllers/snapshotenvironmentbinding_controller.go
@@ -157,7 +157,7 @@ func addTargetIfNotExists(secret *rapi.RemoteSecret, target rapi.RemoteSecretTar
 }
 
 func removeTarget(secret *rapi.RemoteSecret, target rapi.RemoteSecretTarget) {
-	tmp := secret.Spec.Targets[:0]
+	tmp := make([]rapi.RemoteSecretTarget, 0, len(secret.Spec.Targets))
 	for _, existingTarget := range secret.Spec.Targets {
 		if !targetsMatch(existingTarget, target) {
 			tmp = append(tmp, existingTarget)

--- a/controllers/snapshotenvironmentbinding_controller.go
+++ b/controllers/snapshotenvironmentbinding_controller.go
@@ -213,6 +213,9 @@ func (f *linkedRemoteSecretsFinalizer) Finalize(ctx context.Context, obj client.
 		return finalizer.Result{}, fmt.Errorf("failed to load environment from cluster: %w", err)
 	}
 	target, err := detectTargetFromEnvironment(ctx, environment)
+	if err != nil {
+		return finalizer.Result{}, fmt.Errorf("failed to detect target from environment: %w", err)
+	}
 
 	for rs := range remoteSecretsList.Items {
 		remoteSecret := remoteSecretsList.Items[rs]

--- a/controllers/snapshotenvironmentbinding_controller.go
+++ b/controllers/snapshotenvironmentbinding_controller.go
@@ -157,12 +157,13 @@ func addTargetIfNotExists(secret *rapi.RemoteSecret, target rapi.RemoteSecretTar
 }
 
 func removeTarget(secret *rapi.RemoteSecret, target rapi.RemoteSecretTarget) {
-	for idx := range secret.Spec.Targets {
-		existingTarget := secret.Spec.Targets[idx]
-		if targetsMatch(existingTarget, target) {
-			secret.Spec.Targets = append(secret.Spec.Targets[:idx], secret.Spec.Targets[idx+1:]...)
+	tmp := secret.Spec.Targets[:0]
+	for _, existingTarget := range secret.Spec.Targets {
+		if !targetsMatch(existingTarget, target) {
+			tmp = append(tmp, existingTarget)
 		}
 	}
+	secret.Spec.Targets = tmp
 }
 
 func targetsMatch(target1, target2 rapi.RemoteSecretTarget) bool {
@@ -205,7 +206,13 @@ func (f *linkedRemoteSecretsFinalizer) Finalize(ctx context.Context, obj client.
 		return finalizer.Result{}, nil
 	}
 
-	target := rapi.RemoteSecretTarget{Namespace: snapshotEnvBinding.Namespace}
+	// Get the Environment CR
+	environment := appstudiov1alpha1.Environment{}
+	err := f.client.Get(ctx, types.NamespacedName{Name: snapshotEnvBinding.Spec.Environment, Namespace: snapshotEnvBinding.Namespace}, &environment)
+	if err != nil {
+		return finalizer.Result{}, fmt.Errorf("failed to load environment from cluster: %w", err)
+	}
+	target, err := detectTargetFromEnvironment(ctx, environment)
 
 	for rs := range remoteSecretsList.Items {
 		remoteSecret := remoteSecretsList.Items[rs]

--- a/integration_tests/snapshotenvironmentbinding_controller_test.go
+++ b/integration_tests/snapshotenvironmentbinding_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/redhat-appstudio/application-api/api/v1alpha1"
 	rapi "github.com/redhat-appstudio/remote-secret/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("SnapshotEnvironmentBinding", func() {
@@ -128,4 +129,60 @@ var _ = Describe("SnapshotEnvironmentBinding", func() {
 
 	})
 
+	Describe("Removes the target for RemoteSecret with SEB removal ", func() {
+
+		env := StandardRemoteEnvironment("test-remote-env")
+
+		testSetup := TestSetup{
+			ToCreate: TestObjects{
+				RemoteSecrets: []*rapi.RemoteSecret{{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "create-target-remotesecret-",
+						Namespace:    env.Namespace,
+						Labels:       map[string]string{"appstudio.redhat.com/application": "test-app", "appstudio.redhat.com/environment": env.Name},
+					},
+					Spec: rapi.RemoteSecretSpec{
+						Secret: rapi.LinkableSecretSpec{
+							Name: "test-remote-secret",
+							Type: "Opaque",
+						},
+					},
+				}},
+				Environments: []*v1alpha1.Environment{env},
+				SnapshotEnvBindings: []*v1alpha1.SnapshotEnvironmentBinding{{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "create-target-snapshotbinding-",
+						Namespace:    env.Namespace,
+						Labels:       map[string]string{"appstudio.redhat.com/application": "test-app", "appstudio.redhat.com/environment": env.Name},
+					},
+					Spec: v1alpha1.SnapshotEnvironmentBindingSpec{
+						Application: "test-app",
+						Environment: env.Name,
+						Components:  []v1alpha1.BindingComponent{},
+					},
+				}},
+			},
+			Behavior: ITestBehavior{},
+		}
+		BeforeEach(func() {
+			testSetup.BeforeEach(nil)
+		})
+
+		var _ = AfterEach(func() {
+			testSetup.AfterEach()
+		})
+
+		It("have the target deleted", func() {
+			//check target is there
+			Expect(testSetup.InCluster.RemoteSecrets[0].Spec.Targets).ToNot(BeEmpty())
+			// delete SEB
+			Expect(ITest.Client.Delete(ITest.Context, testSetup.InCluster.SnapshotEnvBindings[0])).To(Succeed())
+			// check target is gone
+			Eventually(func(g Gomega) {
+				rs := &rapi.RemoteSecret{}
+				g.Expect(ITest.Client.Get(ITest.Context, types.NamespacedName{Name: testSetup.InCluster.RemoteSecrets[0].Name, Namespace: testSetup.InCluster.RemoteSecrets[0].Namespace}, rs)).To(Succeed())
+				g.Expect(rs.Spec.Targets).To(BeEmpty())
+			}).Should(Succeed())
+		})
+	})
 })


### PR DESCRIPTION
### What does this PR do?
Fix panic in targets cleanup fuction and add more accurate target calculation in cleanup.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->
https://issues.redhat.com/browse/SVPI-614

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
