### PR TITLE
feat: SPIFileContentRequest support for RemoteSecret

### DIFF
--- a/api/v1beta1/spifilecontentrequest_types.go
+++ b/api/v1beta1/spifilecontentrequest_types.go
@@ -14,7 +14,9 @@
 
 package v1beta1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 type SPIFileContentRequestSpec struct {
 	// FilePath defines target file path inside repository
@@ -82,6 +84,14 @@ func init() {
 	SchemeBuilder.Register(&SPIFileContentRequest{}, &SPIFileContentRequestList{})
 }
 
-func (in *SPIFileContentRequest) RepoUrl() string {
-	return in.Spec.RepoUrl
+func (req *SPIFileContentRequest) RepoUrl() string {
+	return req.Spec.RepoUrl
+}
+
+func (req *SPIFileContentRequest) Permissions() *Permissions {
+	return &Permissions{}
+}
+
+func (req *SPIFileContentRequest) ObjNamespace() string {
+	return req.Namespace
 }

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -194,7 +194,7 @@ var _ = BeforeSuite(func() {
 
 	ITest.Capabilities = serviceprovider.TestCapabilities{}
 
-	ITest.Capabilities.DownloadFileImpl = func(_ context.Context, _ string, _ string, _ string, _ *api.SPIAccessToken, i int) (string, error) {
+	ITest.Capabilities.DownloadFileImpl = func(_ context.Context, _ string, _ string, _ string, _ serviceprovider.Credentials, i int) (string, error) {
 		return "abcdefg", nil
 	}
 

--- a/pkg/serviceprovider/clientbuilder.go
+++ b/pkg/serviceprovider/clientbuilder.go
@@ -14,7 +14,11 @@
 
 package serviceprovider
 
-import "context"
+import (
+	"context"
+
+	"github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+)
 
 type AuthenticatedClientBuilder[C any] interface {
 	CreateAuthenticatedClient(ctx context.Context, credentials Credentials) (*C, error)
@@ -23,4 +27,11 @@ type AuthenticatedClientBuilder[C any] interface {
 type Credentials struct {
 	Username string
 	Token    string
+}
+
+func CredentialsFromToken(token v1beta1.Token) Credentials {
+	return Credentials{
+		Username: token.Username,
+		Token:    token.AccessToken,
+	}
 }

--- a/pkg/serviceprovider/downloadfilecapability.go
+++ b/pkg/serviceprovider/downloadfilecapability.go
@@ -16,8 +16,6 @@ package serviceprovider
 
 import (
 	"context"
-
-	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 )
 
 type FileDownloadNotSupportedError struct {
@@ -29,5 +27,5 @@ func (f FileDownloadNotSupportedError) Error() string {
 
 // DownloadFileCapability indicates an ability of given SCM provider to download files from repository.
 type DownloadFileCapability interface {
-	DownloadFile(ctx context.Context, repoUrl, filepath, ref string, token *api.SPIAccessToken, maxFileSizeLimit int) (string, error)
+	DownloadFile(ctx context.Context, repoUrl, filepath, ref string, credentials Credentials, maxFileSizeLimit int) (string, error)
 }

--- a/pkg/serviceprovider/github/downloadfilecapability.go
+++ b/pkg/serviceprovider/github/downloadfilecapability.go
@@ -25,14 +25,13 @@ import (
 	"github.com/redhat-appstudio/remote-secret/pkg/logs"
 
 	"github.com/google/go-github/v45/github"
-	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type downloadFileCapability struct {
 	httpClient      *http.Client
-	ghClientBuilder githubClientBuilder
+	ghClientBuilder serviceprovider.AuthenticatedClientBuilder[github.Client]
 	ghBaseUrl       string
 	ghRepoRegexp    *regexp.Regexp
 }
@@ -60,13 +59,13 @@ func NewDownloadFileCapability(httpClient *http.Client, ghClientBuilder githubCl
 	}, nil
 }
 
-func (d downloadFileCapability) DownloadFile(ctx context.Context, repoUrl, filepath, ref string, token *api.SPIAccessToken, maxFileSizeLimit int) (string, error) {
+func (d downloadFileCapability) DownloadFile(ctx context.Context, repoUrl, filepath, ref string, credentials serviceprovider.Credentials, maxFileSizeLimit int) (string, error) {
 	owner, repo, err := d.parseOwnerAndRepoFromUrl(ctx, repoUrl)
 	if err != nil {
 		return "", fmt.Errorf("could not parse repository name and owner from repoUrl: %w", err)
 	}
 	lg := log.FromContext(ctx)
-	ghClient, err := d.ghClientBuilder.createAuthenticatedGhClient(ctx, token)
+	ghClient, err := d.ghClientBuilder.CreateAuthenticatedClient(ctx, credentials)
 	if err != nil {
 		return "", fmt.Errorf("failed to create authenticated GitHub client: %w", err)
 	}

--- a/pkg/serviceprovider/github/downloadfilecapability_test.go
+++ b/pkg/serviceprovider/github/downloadfilecapability_test.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
+
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/stretchr/testify/assert"
@@ -70,7 +72,7 @@ func TestGetFileHead(t *testing.T) {
 	fileCapability, capabilityErr := NewDownloadFileCapability(client, githubClientBuilder, "https://github.com")
 	assert.NoError(t, capabilityErr)
 
-	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "HEAD", &api.SPIAccessToken{}, 1024)
+	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "HEAD", serviceprovider.Credentials{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -120,7 +122,7 @@ func TestGetFileHeadGitSuffix(t *testing.T) {
 	fileCapability, capabilityErr := NewDownloadFileCapability(client, githubClientBuilder, "https://github.com")
 	assert.NoError(t, capabilityErr)
 
-	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo.git", "myfile", "HEAD", &api.SPIAccessToken{}, 1024)
+	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo.git", "myfile", "HEAD", serviceprovider.Credentials{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -169,7 +171,7 @@ func TestGetFileOnBranch(t *testing.T) {
 	fileCapability, capabilityErr := NewDownloadFileCapability(client, githubClientBuilder, "https://github.com")
 	assert.NoError(t, capabilityErr)
 
-	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "v0.1.0", &api.SPIAccessToken{}, 1024)
+	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "v0.1.0", serviceprovider.Credentials{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -220,7 +222,7 @@ func TestGetFileOnCommitId(t *testing.T) {
 	fileCapability, capabilityErr := NewDownloadFileCapability(client, githubClientBuilder, "https://github.com")
 	assert.NoError(t, capabilityErr)
 
-	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", &api.SPIAccessToken{}, 1024)
+	content, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", serviceprovider.Credentials{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -260,7 +262,7 @@ func TestGetUnexistingFile(t *testing.T) {
 	fileCapability, capabilityErr := NewDownloadFileCapability(&http.Client{}, githubClientBuilder, "https://github.com")
 	assert.NoError(t, capabilityErr)
 
-	_, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", &api.SPIAccessToken{}, 1024)
+	_, err := fileCapability.DownloadFile(context.TODO(), "https://github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", serviceprovider.Credentials{}, 1024)
 	if err == nil {
 		t.Error("error expected")
 	}
@@ -273,7 +275,7 @@ func TestInvalidRepoUrl(t *testing.T) {
 		fileCapability, err := NewDownloadFileCapability(&http.Client{}, githubClientBuilder{}, "https://github.com")
 		assert.NoError(t, err)
 
-		c, err := fileCapability.DownloadFile(context.TODO(), repoUrl, "myfile", "bla", &api.SPIAccessToken{}, 1024)
+		c, err := fileCapability.DownloadFile(context.TODO(), repoUrl, "myfile", "bla", serviceprovider.Credentials{}, 1024)
 
 		assert.Error(t, err)
 		assert.Empty(t, c)

--- a/pkg/serviceprovider/github/github.go
+++ b/pkg/serviceprovider/github/github.go
@@ -215,6 +215,14 @@ func (g *Github) LookupTokens(ctx context.Context, cl client.Client, binding *ap
 	return tokens, nil
 }
 
+func (g *Github) CredentialsFromRS(ctx context.Context, cl client.Client, contentRequest *api.SPIFileContentRequest) (*serviceprovider.Credentials, error) {
+	credentials, err := g.lookup.LookupCredentialsFromRS(ctx, cl, contentRequest)
+	if err != nil {
+		return nil, fmt.Errorf("github token credentials lookup from RemoteSecret failure: %w", err)
+	}
+	return credentials, nil
+}
+
 func (g *Github) PersistMetadata(ctx context.Context, _ client.Client, token *api.SPIAccessToken) error {
 	if err := g.lookup.PersistMetadata(ctx, token); err != nil {
 		return fmt.Errorf("failed to persist github metadata: %w", err)

--- a/pkg/serviceprovider/github/githubclientbuilder.go
+++ b/pkg/serviceprovider/github/githubclientbuilder.go
@@ -16,18 +16,13 @@ package github
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 
 	"github.com/google/go-github/v45/github"
-	"github.com/redhat-appstudio/remote-secret/pkg/logs"
-	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"golang.org/x/oauth2"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type githubClientBuilder struct {
@@ -42,30 +37,3 @@ func (g githubClientBuilder) CreateAuthenticatedClient(ctx context.Context, cred
 }
 
 var _ serviceprovider.AuthenticatedClientBuilder[github.Client] = (*githubClientBuilder)(nil)
-
-var accessTokenNotFoundError = errors.New("token data is not found in token storage")
-
-func (g githubClientBuilder) createAuthenticatedGhClient(ctx context.Context, spiToken *api.SPIAccessToken) (*github.Client, error) {
-	tokenData, tsErr := g.tokenStorage.Get(ctx, spiToken)
-	lg := log.FromContext(ctx)
-	if tsErr != nil {
-
-		lg.Error(tsErr, "failed to get token from storage for", "token", spiToken)
-		return nil, fmt.Errorf("failed to get token from storage for %s/%s: %w", spiToken.Namespace, spiToken.Name, tsErr)
-	}
-	if tokenData == nil {
-		lg.Error(accessTokenNotFoundError, "token data not found", "token-name", spiToken.Name)
-		return nil, accessTokenNotFoundError
-	}
-	client, err := g.CreateAuthenticatedClient(ctx, serviceprovider.Credentials{Token: tokenData.AccessToken})
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct authenticated GitHub client: %w", err)
-	}
-	lg.V(logs.DebugLevel).Info("Created new authenticated GitHub client", "SPIAccessToken", spiToken)
-
-	// We need the githubBaseUrl in the githubClientBuilder struct to decide whether to create
-	// regular GitHub client or an Enterprise client through the GitHub library's NewEnterpriseClient() function.
-	// However, the function takes 2 URLs as parameters: one for the API URL and one for the upload URL where files can be uploaded.
-	// As we currently do not allow uploading files to GitHub, we might omit the uploadURL.
-	return client, nil
-}

--- a/pkg/serviceprovider/github/metadataprovider.go
+++ b/pkg/serviceprovider/github/metadataprovider.go
@@ -95,7 +95,7 @@ func (s metadataProvider) doFetch(ctx context.Context, token *api.SPIAccessToken
 		AccessibleRepos: map[RepositoryUrl]RepositoryRecord{},
 	}
 
-	ghClient, err := s.ghClientBuilder.createAuthenticatedGhClient(ctx, token)
+	ghClient, err := s.ghClientBuilder.CreateAuthenticatedClient(ctx, serviceprovider.CredentialsFromToken(*data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create authenticated GitHub client: %w", err)
 	}

--- a/pkg/serviceprovider/gitlab/downloadfilecapability_test.go
+++ b/pkg/serviceprovider/gitlab/downloadfilecapability_test.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
+
 	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/stretchr/testify/assert"
@@ -74,7 +76,7 @@ func TestGetFileHead(t *testing.T) {
 	assert.NoError(t, err)
 
 	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com", repoUrlMatcher)
-	content, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo", "myfile", "", &api.SPIAccessToken{}, 1024)
+	content, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo", "myfile", "", serviceprovider.Credentials{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -125,7 +127,7 @@ func TestGetFileHeadGitSuffix(t *testing.T) {
 	assert.NoError(t, err)
 
 	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com", repoUrlMatcher)
-	content, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo.git", "myfile", "", &api.SPIAccessToken{}, 1024)
+	content, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo.git", "myfile", "", serviceprovider.Credentials{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -176,7 +178,7 @@ func TestGetFileOnBranch(t *testing.T) {
 	assert.NoError(t, err)
 
 	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com", repoUrlMatcher)
-	content, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo.git", "myfile", "v0.1.0", &api.SPIAccessToken{}, 1024)
+	content, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo.git", "myfile", "v0.1.0", serviceprovider.Credentials{}, 1024)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -218,7 +220,7 @@ func TestGetUnexistingFile(t *testing.T) {
 	assert.NoError(t, matcherErr)
 
 	fileCapability := NewDownloadFileCapability(client, gitlabClientBuilder, "https://fake.github.com", repoUrlMatcher)
-	_, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", &api.SPIAccessToken{}, 1024)
+	_, err := fileCapability.DownloadFile(context.TODO(), "https://fake.github.com/foo-user/foo-repo", "myfile", "efaf08a367921ae130c524db4a531b7696b7d967", serviceprovider.Credentials{}, 1024)
 	if err == nil {
 		t.Error("error expected")
 	}

--- a/pkg/serviceprovider/gitlab/gitlab.go
+++ b/pkg/serviceprovider/gitlab/gitlab.go
@@ -137,6 +137,14 @@ func (g *Gitlab) LookupTokens(ctx context.Context, cl client.Client, binding *ap
 	return tokens, nil
 }
 
+func (g *Gitlab) CredentialsFromRS(ctx context.Context, cl client.Client, contentRequest *api.SPIFileContentRequest) (*serviceprovider.Credentials, error) {
+	credentials, err := g.lookup.LookupCredentialsFromRS(ctx, cl, contentRequest)
+	if err != nil {
+		return nil, fmt.Errorf("gitlab token credentials lookup from RemoteSecret failure: %w", err)
+	}
+	return credentials, nil
+}
+
 func (g *Gitlab) PersistMetadata(ctx context.Context, _ client.Client, token *api.SPIAccessToken) error {
 	if err := g.lookup.PersistMetadata(ctx, token); err != nil {
 		return fmt.Errorf("failed to persist gitlab metadata: %w", err)

--- a/pkg/serviceprovider/gitlab/gitlabclientbuilder.go
+++ b/pkg/serviceprovider/gitlab/gitlabclientbuilder.go
@@ -16,17 +16,13 @@ package gitlab
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/serviceprovider"
 
-	"github.com/redhat-appstudio/remote-secret/pkg/logs"
-	api "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	"github.com/redhat-appstudio/service-provider-integration-operator/pkg/spi-shared/tokenstorage"
 	"github.com/xanzy/go-gitlab"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type gitlabClientBuilder struct {
@@ -37,33 +33,10 @@ type gitlabClientBuilder struct {
 
 var _ serviceprovider.AuthenticatedClientBuilder[gitlab.Client] = (*gitlabClientBuilder)(nil)
 
-var accessTokenNotFoundError = errors.New("token data is not found in token storage")
-
-func (builder gitlabClientBuilder) CreateAuthenticatedClient(ctx context.Context, credentials serviceprovider.Credentials) (*gitlab.Client, error) {
+func (builder gitlabClientBuilder) CreateAuthenticatedClient(_ context.Context, credentials serviceprovider.Credentials) (*gitlab.Client, error) {
 	client, err := gitlab.NewOAuthClient(credentials.Token, gitlab.WithHTTPClient(builder.httpClient), gitlab.WithBaseURL(builder.gitlabBaseUrl))
 	if err != nil {
 		return nil, fmt.Errorf("failed to created new authenticated GitLab client: %w", err)
 	}
-	return client, nil
-}
-
-func (builder gitlabClientBuilder) createGitlabAuthClient(ctx context.Context, spiAccessToken *api.SPIAccessToken) (*gitlab.Client, error) {
-	lg := log.FromContext(ctx)
-	tokenData, err := builder.tokenStorage.Get(ctx, spiAccessToken)
-	if err != nil {
-		lg.Error(err, "failed to get token from storage for", "token", spiAccessToken)
-		return nil, fmt.Errorf("failed to get token from storage for %s/%s: %w",
-			spiAccessToken.Namespace, spiAccessToken.Name, err)
-	}
-
-	if tokenData == nil {
-		lg.Error(accessTokenNotFoundError, "token data not found", "token-name", spiAccessToken.Name)
-		return nil, accessTokenNotFoundError
-	}
-	client, err := builder.CreateAuthenticatedClient(ctx, serviceprovider.Credentials{Token: tokenData.AccessToken})
-	if err != nil {
-		return nil, err
-	}
-	lg.V(logs.DebugLevel).Info("new authenticated gitlab client successfully created", "SPIAccessToken", spiAccessToken)
 	return client, nil
 }

--- a/pkg/serviceprovider/hostcredentials/hostcredentials.go
+++ b/pkg/serviceprovider/hostcredentials/hostcredentials.go
@@ -87,6 +87,14 @@ func (g *HostCredentialsProvider) LookupTokens(ctx context.Context, cl client.Cl
 	return tokens, nil
 }
 
+func (g *HostCredentialsProvider) CredentialsFromRS(ctx context.Context, cl client.Client, contentRequest *api.SPIFileContentRequest) (*serviceprovider.Credentials, error) {
+	credentials, err := g.lookup.LookupCredentialsFromRS(ctx, cl, contentRequest)
+	if err != nil {
+		return nil, fmt.Errorf("quay token credentials lookup from RemoteSecret failure: %w", err)
+	}
+	return credentials, nil
+}
+
 func (g *HostCredentialsProvider) PersistMetadata(ctx context.Context, _ client.Client, token *api.SPIAccessToken) error {
 	err := g.lookup.PersistMetadata(ctx, token)
 	if err != nil {

--- a/pkg/serviceprovider/lookup.go
+++ b/pkg/serviceprovider/lookup.go
@@ -171,9 +171,14 @@ func (l GenericLookup) LookupCredentials(ctx context.Context, cl client.Client, 
 		if tokenData == nil {
 			return nil, accessTokenNotFoundError
 		}
-		return &Credentials{Username: tokenData.Username, Token: tokenData.AccessToken}, nil
+		credentials := CredentialsFromToken(*tokenData)
+		return &credentials, nil
 	}
 
+	return l.LookupCredentialsFromRS(ctx, cl, matchable)
+}
+
+func (l GenericLookup) LookupCredentialsFromRS(ctx context.Context, cl client.Client, matchable Matchable) (*Credentials, error) {
 	remoteSecrets, err := l.lookupRemoteSecrets(ctx, cl, matchable)
 	if err != nil {
 		return nil, err

--- a/pkg/serviceprovider/quay/quay.go
+++ b/pkg/serviceprovider/quay/quay.go
@@ -186,6 +186,14 @@ func (q *Quay) LookupTokens(ctx context.Context, cl client.Client, binding *api.
 	return tokens, nil
 }
 
+func (q *Quay) CredentialsFromRS(ctx context.Context, cl client.Client, contentRequest *api.SPIFileContentRequest) (*serviceprovider.Credentials, error) {
+	credentials, err := q.lookup.LookupCredentialsFromRS(ctx, cl, contentRequest)
+	if err != nil {
+		return nil, fmt.Errorf("quay token credentials lookup from RemoteSecret failure: %w", err)
+	}
+	return credentials, nil
+}
+
 func (q *Quay) PersistMetadata(ctx context.Context, _ client.Client, token *api.SPIAccessToken) error {
 	if err := q.lookup.PersistMetadata(ctx, token); err != nil {
 		return fmt.Errorf("failed to persiste quay metadata: %w", err)

--- a/pkg/serviceprovider/serviceprovider.go
+++ b/pkg/serviceprovider/serviceprovider.go
@@ -41,6 +41,8 @@ type ServiceProvider interface {
 	// mechanism (usually an http client)).
 	LookupTokens(ctx context.Context, cl client.Client, binding *api.SPIAccessTokenBinding) ([]api.SPIAccessToken, error)
 
+	CredentialsFromRS(ctx context.Context, cl client.Client, contentRequest *api.SPIFileContentRequest) (*Credentials, error)
+
 	// PersistMetadata tries to use the OAuth access token associated with the provided token (if any) and persists any
 	// state and metadata required for the token lookup. The metadata must be stored in the Status.TokenMetadata field
 	// of the provided token.

--- a/pkg/serviceprovider/serviceprovider_mock.go
+++ b/pkg/serviceprovider/serviceprovider_mock.go
@@ -31,6 +31,7 @@ import (
 // that no null pointer dereferences should occur under normal operation.
 type TestServiceProvider struct {
 	LookupTokensImpl          func(context.Context, client.Client, *api.SPIAccessTokenBinding) ([]api.SPIAccessToken, error)
+	CredentialsFromRSImpl     func(context.Context, client.Client, *api.SPIFileContentRequest) (*Credentials, error)
 	PersistMetadataImpl       func(context.Context, client.Client, *api.SPIAccessToken) error
 	GetBaseUrlImpl            func() string
 	GetTypeImpl               func() config.ServiceProviderType
@@ -57,6 +58,13 @@ func (t TestServiceProvider) LookupTokens(ctx context.Context, cl client.Client,
 		return nil, nil
 	}
 	return t.LookupTokensImpl(ctx, cl, binding)
+}
+
+func (t TestServiceProvider) CredentialsFromRS(ctx context.Context, cl client.Client, contentRequest *api.SPIFileContentRequest) (*Credentials, error) {
+	if t.CredentialsFromRSImpl == nil {
+		return nil, nil
+	}
+	return t.CredentialsFromRSImpl(ctx, cl, contentRequest)
 }
 
 func (t TestServiceProvider) PersistMetadata(ctx context.Context, cl client.Client, token *api.SPIAccessToken) error {
@@ -137,7 +145,7 @@ func (t *TestServiceProvider) Reset() {
 // TestCapabilities is a test implementation for capabilities that Service Provider can have.
 // Currently, it aggregates DownloadFileCapability and OAuthCapability. All of these have valid results (i.e. do not result in any errors).
 type TestCapabilities struct {
-	DownloadFileImpl     func(context.Context, string, string, string, *api.SPIAccessToken, int) (string, error)
+	DownloadFileImpl     func(context.Context, string, string, string, Credentials, int) (string, error)
 	GetOAuthEndpointImpl func() string
 	OAuthScopesForImpl   func(permission *api.Permissions) []string
 	RefreshTokenImpl     func(ctx context.Context, token *api.Token, config *oauth2.Config) (*api.Token, error)
@@ -147,9 +155,9 @@ var _ DownloadFileCapability = (*TestCapabilities)(nil)
 var _ OAuthCapability = (*TestCapabilities)(nil)
 var _ RefreshTokenCapability = (*TestCapabilities)(nil)
 
-func (t *TestCapabilities) DownloadFile(ctx context.Context, repoUrl, filepath, ref string, token *api.SPIAccessToken, maxFileSizeLimit int) (string, error) {
+func (t *TestCapabilities) DownloadFile(ctx context.Context, repoUrl, filepath, ref string, credentials Credentials, maxFileSizeLimit int) (string, error) {
 	if t.DownloadFileImpl != nil {
-		return t.DownloadFileImpl(ctx, repoUrl, filepath, ref, token, maxFileSizeLimit)
+		return t.DownloadFileImpl(ctx, repoUrl, filepath, ref, credentials, maxFileSizeLimit)
 	}
 
 	return "", nil


### PR DESCRIPTION
### What does this PR do?
Enables SPIFileContentRequest to use credentials from RemoteSecret. It uses the same search algorithm for RemoteSecrets used in SPIAccessCheck (read more [here](https://github.com/redhat-appstudio/service-provider-integration-operator/pull/691) https://github.com/redhat-appstudio/service-provider-integration-operator/pull/691)

The reconcile logic is changed so that before creating binding and waiting for token, it searches for RemoteSecret it could use. If any is found, it uses the credentials and delivers the content. This fully preserves backward compatibility but complicates the reconciliation. Check #706 for version breaking the compatibility.

#### Negatives of current implementation
Because the logic is happening mostly on the reconcile level, where the fileDownload is initiated, the reconciler needs to access the token storage and also needs access to the RemoteSecret search, which is done two levels down in the GenericLookup.

#### More context
The idea was to make the SPIFileContentRequest behave similarly to SPIAccessCheck. However, they are different beasts. Most of the logic in SPIAccessCheck happens in the service provider's CheckRepositoryAccess method, whereas most of SPIFileContentRequest's logic happens in the reconcile. SPIFileContentRequest creates a SPIAccessTokenBinding and yields the token lookup to that binding. After an SPIAccessToken is linked to a binding, the SPIFileContentRequest uses this token to download the file content.

Consequently, one can only download a file with a token, even if it is a public repo. @mshaposhnik and @metlos pointed out that one of the reasons for this is that the GitHub API rate limit without a token is quite strict, and we would quickly hit it. In SPIAccessCheck, we avoid this rate limit for public repositories because we do a GET request on the repo website, not the API. (Maybe we could do something similar with SPIFileContentRequest???)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what this PR is doing -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from SPI repository (or from another issue tracker).
     Include link to other pull requests like documentation PR, etc.
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method.
  - steps to reproduce.
 -->

```
quay.io/redhat-appstudio/pull-request-builds:spi-controller-#
quay.io/redhat-appstudio/pull-request-builds:spi-oauth-#
```
