### PR TITLE
fix the Restore cache failed warning of the github actions job

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -6,11 +6,11 @@ jobs:
     name: golangci
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
           go-version: "1.21"
-      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,10 @@ jobs:
     env:
       OPERATOR_SDK_VERSION: v1.12.0
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
@@ -34,10 +38,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Cache Operator SDK ${{ env.OPERATOR_SDK_VERSION }}
         uses: actions/cache@v3
         id: cache-operator-sdk


### PR DESCRIPTION
### What does this PR do?
 - actions/setup-go provides module-caching feature for dependencies [from v4](https://github.com/actions/setup-go/releases/tag/v4.0.0).
- However, the cache is not working correctly in the current job configuration.
One of the example job results is https://github.com/redhat-appstudio/service-provider-integration-operator/actions/runs/6495456060 with the warning message Restore cache failed: Dependencies file is not found in /home/runner/work/viper/viper. Supported file pattern: go.sum.

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
n/a

### How to test this PR?
n/a