### PR TITLE
Sync kube-linter version with infra-deployment

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -69,6 +69,9 @@ jobs:
         uses: stackrox/kube-linter-action@v1
         id: kube-linter-action-scan
         with:
+          # version 0.6.6 contains a new liveness check. We do have a few liveness issue already so use previous version for now
+          # Once we fix all issues, we will revert to use latest again.
+          version: v0.6.5
           # Adjust this directory to the location where your kubernetes resources and helm charts are located.
           directory: ./.kube-linter/
           # Adjust this to the location of kube-linter config you're using, or remove the setting if you'd like to use


### PR DESCRIPTION
### What does this PR do?
{SUBJ}
https://github.com/redhat-appstudio/infra-deployments/blob/b0f8378cca271810ea0b2512d1a236673f2f50ff/.github/workflows/kube-linter.yaml#L34-L36
### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
0.6.6 version complains about liveness probs configuration

### How to test this PR?
n/a