### PR TITLE
fix(pact): post pact results just after PR merge

### DIFF
--- a/.github/workflows/pact.yaml
+++ b/.github/workflows/pact.yaml
@@ -19,10 +19,6 @@ on:
   push:
     branches:
       - main
-  # will be removed, just for testing in a PR
-  pull_request:
-    branches: [main]
-  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
### What does this PR do?
Post Pact results to the Broker just after PR is merged, not during PR checks.